### PR TITLE
Ultrachess DeFi Tokenomics for non-zero-sum betting

### DIFF
--- a/contracts/src/interfaces/token/routes/ICurveAavePooler.sol
+++ b/contracts/src/interfaces/token/routes/ICurveAavePooler.sol
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/contracts
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+pragma solidity 0.8.16;
+
+/**
+ * @dev Token router to add liquidity to the Curve Aave pool in exchange for
+ * LP tokens
+ *
+ * This contract provides an interface for adding and removing liquidity in the
+ * Curve Aave pool as a single transaction.
+ */
+abstract contract ICurveAavePooler {
+  //////////////////////////////////////////////////////////////////////////////
+  // Events
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Emitted when liquidity is added to the Curve Aave pool
+   *
+   * @param sender The sender of the underlying stablecoins
+   * @param recipient The address of the recipient of the LP tokens
+   * @param stableAmounts The amounts of stablecoins added to the pool
+   *                      (0 = DAI, 1 = USDC, 2 = USDT)
+   * @param lpTokenAmount The amount of LP tokens received
+   */
+  event LiquidityAdded(
+    address indexed sender,
+    address indexed recipient,
+    uint256[3] stableAmounts,
+    uint256 lpTokenAmount
+  );
+
+  /**
+   * @dev Emitted when liquidity is removed from the Curve Aave pool
+   *
+   * @param sender The sender
+   * @param recipient The recipient of the underlying stablecoin
+   * @param lpTokenAmount The amount of LP tokens burned
+   * @param stableIndex The index of the stablecoin returned
+   *                    (0 = DAI, 1 = USDC, 2 = USDT)
+   * @param stablesReturned The amount of stablecoins returned to the
+   *                        recipient
+   */
+  event LiquidityRemovedOneStable(
+    address indexed sender,
+    address indexed recipient,
+    uint256 lpTokenAmount,
+    uint256 stableIndex,
+    uint256 stablesReturned
+  );
+
+  //////////////////////////////////////////////////////////////////////////////
+  // External interface for adding liquidity
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Add an amount of underlying stablecoins to the pool and return the
+   * LP tokens
+   *
+   * @param stableAmounts The amounts of the underlying stablecoins to add
+   *                      (0 = DAI, 1 = USDC, 2 = USDT)
+   * @param minMintAmount The minimum amount of the LP token to mint
+   * @param recipient The recipient of the CurveLP tokens
+   *
+   * @return lpTokenAmount The amount of LP tokens minted and returned to the
+   *                       recipient
+   */
+  function addLiquidity(
+    uint256[3] memory stableAmounts,
+    uint256 minMintAmount,
+    address recipient
+  ) external virtual returns (uint256 lpTokenAmount);
+
+  /**
+   * @dev Add an amount of a single underlying stablecoin to the pool
+   * return the LP tokens
+   *
+   * @param stableIndex The index of the stablecoin to add
+   *                    (0 = DAI, 1 = USDC, 2 = USDT)
+   * @param stableAmount The amount of the underlying stablecoin to add
+   *
+   * @return lpTokenAmount The amount of LP tokens minted and returned to the
+   *                       recipient
+   */
+  function addLiquidityOneStable(
+    uint256 stableIndex,
+    uint256 stableAmount
+  ) external virtual returns (uint256 lpTokenAmount);
+
+  //////////////////////////////////////////////////////////////////////////////
+  // External interface for removing liquidity
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Remove an amount of LP tokens from the pool and return the amount as
+   * a single token
+   *
+   * @param lpTokenAmount The amount of the LP token to remove
+   * @param stableIndex The index of the stablecoin to receive
+   *                    (0 = DAI, 1 = USDC, 2 = USDT)
+   * @param minTokenAmount The minimum amount of the token to receive
+   * @param recipient The recipient of the underlying stablecoin
+   *
+   * @return stablesReturned The amount of the underlying stablecoin returned
+   *                         to the recipient
+   */
+  function removeLiquidityOneStable(
+    uint256 lpTokenAmount,
+    uint256 stableIndex,
+    uint256 minTokenAmount,
+    address recipient
+  ) external virtual returns (uint256 stablesReturned);
+
+  /**
+   * @dev Remove all liquidity as a single token in one function call
+   *
+   * @param stableIndex The index of the stablecoin to withdraw (0 = DAI, 1 = USDC, 2 = USDT)
+   *
+   * @return stablesReturned The amount of stablecoins returned to the sender
+   */
+  function exitOneStable(
+    uint256 stableIndex
+  ) external virtual returns (uint256 stablesReturned);
+
+  //////////////////////////////////////////////////////////////////////////////
+  // External interface for reading state
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Get the current virtual price of the pool LP token
+   *
+   * The virtual price in Curve is obtained through taking the invariance of
+   * the pool, which by default takes every stablecoin as valued at 1.00 USD.
+   *
+   * The virtual price measures pool growth; this is not a dollar value.
+   *
+   * @return virtualPrice The LP token virtual price normalized to 1e18
+   */
+  function getVirtualPrice()
+    external
+    view
+    virtual
+    returns (uint256 virtualPrice);
+
+  /**
+   * @dev Get the amount of LP tokens that would be minted or burned for a
+   * given amount of underlying stablecoins
+   *
+   * @param stableAmounts The amount of each underlying stablecoin to add
+   *                      or remove
+   * @param isDeposit True if the amounts are being added to the pool, false
+   *                   if they are being removed
+   *
+   * @return mintAmount The amount of LP tokens that would be minted
+   */
+  function getLpAmount(
+    uint256[3] memory stableAmounts,
+    bool isDeposit
+  ) external view virtual returns (uint256 mintAmount);
+
+  /**
+   * @dev Calculate the amount of underlying stablecoins that would be returned
+   * for a given amount of LP tokens
+   *
+   * @param lpTokenAmount The amount of LP tokens to remove
+   * @param stableIndex The index of the stablecoin to receive
+   *                    (0 = DAI, 1 = USDC, 2 = USDT)
+   *
+   * @return stableAmount The amount of the underlying stablecoin that would
+   *                      be returned
+   */
+  function getStableAmount(
+    uint256 lpTokenAmount,
+    uint256 stableIndex
+  ) external view virtual returns (uint256 stableAmount);
+}

--- a/contracts/src/interfaces/token/routes/ICurveAaveStaker.sol
+++ b/contracts/src/interfaces/token/routes/ICurveAaveStaker.sol
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/contracts
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+pragma solidity 0.8.16;
+
+/**
+ * @dev Token router to stake stablecoins to the Curve Aave gauge in exchange
+ * for asset tokens
+ *
+ * This contract provides an interface for staking and unstaking stablecoins in
+ * the Curve Aave gauge as a single transaction.
+ *
+ * TODO: Staking in the gauge generates rewards in the form of CRV tokens.
+ * These tokens are yet not managed by this contract.
+ */
+abstract contract ICurveAaveStaker {
+  //////////////////////////////////////////////////////////////////////////////
+  // Events
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Emitted when stablecoins are staked to the Curve Aave gauge
+   *
+   * @param sender The sender of the underlying stablecoins
+   * @param recipient The address of the recipient of the gauge shares
+   * @param stableAmounts The amounts of stablecoins staked to the gauge
+   *                      (0 = DAI, 1 = USDC, 2 = USDT)
+   * @param gaugeShares The amount of gauge shares received
+   */
+  event GaugeStaked(
+    address indexed sender,
+    address indexed recipient,
+    uint256[3] stableAmounts,
+    uint256 gaugeShares
+  );
+
+  /**
+   * @dev Emitted when stablecoins are unstaked from the Curve Aave gauge
+   *
+   * @param sender The sender
+   * @param recipient The address of the recipient of the single stablecoin
+   * @param gaugeShares The amount of gauge shares unstaked from the gauge
+   * @param stableIndex The index of the stablecoin to return
+   *                    (0 = DAI, 1 = USDC, 2 = USDT)
+   * @param stablesReturned The amount of stablecoins returned to the recipient
+   */
+  event GaugeUnstakedOneStable(
+    address indexed sender,
+    address indexed recipient,
+    uint256 gaugeShares,
+    uint256 stableIndex,
+    uint256 stablesReturned
+  );
+
+  //////////////////////////////////////////////////////////////////////////////
+  // External interface for staking
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Stake an amount of underlying stablecoins to the gauge and return
+   * the asset token representing the staked amount
+   *
+   * @param stableAmounts The amounts of the underlying stablecoins to stake
+   *                      (0 = DAI, 1 = USDC, 2 = USDT)
+   * @param recipient The recipient of the asset tokens
+   *
+   * @return assetTokenAmount The amount of gauge shares minted and returned
+   * to the recipient
+   */
+  function stakeTokens(
+    uint256[3] memory stableAmounts,
+    address recipient
+  ) external virtual returns (uint256 assetTokenAmount);
+
+  /**
+   * @dev Stake a single underlying stablecoin to the gauge and return the
+   * gauge shares
+   *
+   * @param stableIndex The index of the stablecoin to stake
+   *                    (DAI = 0, USDC = 1, USDT = 2)
+   * @param stableAmount The amount of the underlying stablecoin to stake
+   *
+   * @return gaugeTokenAmount The amount of gauge shares minted and returned
+   */
+  function stakeOneStable(
+    uint256 stableIndex,
+    uint256 stableAmount
+  ) external virtual returns (uint256 gaugeTokenAmount);
+
+  //////////////////////////////////////////////////////////////////////////////
+  // External interface for unstaking
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Unstake an amount of gauge shares from the gauge and return the
+   * amount as a single underlying stablecoin
+   *
+   * @param assetTokenAmount The amount of asset tokens being redeemed
+   * @param stableIndex The index of the stablecoin to receive
+   *                    (0 = DAI, 1 = USDC, 2 = USDT)
+   * @param recipient The recipient of the underlying stablecoin
+   *
+   * @return stablesReturned The amount of the underlying stablecoin returned
+   *                         to the recipient
+   */
+  function unstakeOneStable(
+    uint256 assetTokenAmount,
+    uint256 stableIndex,
+    address recipient
+  ) external virtual returns (uint256 stablesReturned);
+
+  /**
+   * @dev Unstake everything as a single stablecoin in one function call
+   *
+   * @param stableIndex The index of the stablecoin to unstake
+   *                    (0 = DAI, 1 = USDC, 2 = USDT)
+   *
+   * @return stablesReturned The amount of stablecoins returned to the sender
+   */
+  function exitOneStable(
+    uint256 stableIndex
+  ) external virtual returns (uint256 stablesReturned);
+
+  //////////////////////////////////////////////////////////////////////////////
+  // External interface for reading state
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Get the current virtual price of the asset token
+   *
+   * The virtual price in Curve is obtained through taking the invariance of
+   * the pool, which by default takes every stablecoin as valued at 1.00 USD.
+   *
+   * The virtual price measures pool growth; this is not a dollar value.
+   *
+   * @return virtualPrice The asset token virtual price normalized to 1e18
+   */
+  function getVirtualPrice()
+    external
+    view
+    virtual
+    returns (uint256 virtualPrice);
+
+  /**
+   * @dev Get the amount of LP tokens that would be minted or burned for a
+   * given amount of underlying stablecoins
+   *
+   * @param stableAmounts The amount of each underlying stablecoin to add or
+   *                      remove
+   * @param isDeposit True if the amounts are being added to the pool, false
+   *                  if they are being removed
+   *
+   * @return assetAmount The amount of asset tokens that would be minted
+   */
+  function getAssetAmount(
+    uint256[3] memory stableAmounts,
+    bool isDeposit
+  ) external view virtual returns (uint256 assetAmount);
+
+  /**
+   * @dev Calculate the amount of underlying stablecoins that would be returned
+   * for a given amount of asset tokens
+   *
+   * @param assetAmount The amount of asset tokens to unstake
+   * @param stableIndex The index of the stablecoin to receive
+   *                    (0 = DAI, 1 = USDC, 2 = USDT)
+   *
+   * @return stableAmount The amount of the underlying stablecoin that would
+   *                      be returned
+   */
+  function getStableAmount(
+    uint256 assetAmount,
+    uint256 stableIndex
+  ) external view virtual returns (uint256 stableAmount);
+}

--- a/contracts/src/interfaces/token/routes/IUniV3Pooler.sol
+++ b/contracts/src/interfaces/token/routes/IUniV3Pooler.sol
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/contracts
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+pragma solidity 0.8.16;
+
+/**
+ * @dev Token router to liquidity to the Uniswap V3 pool in exchange for an
+ * LP NFT
+ */
+abstract contract IUniV3Pooler {
+  //////////////////////////////////////////////////////////////////////////////
+  // Events
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Emitted when a Uniswap V3 LP NFT is minted
+   *
+   * @param sender The sender of the underlying stablecoins
+   * @param recipient The address of the recipient of the LP NFT
+   * @param nftAddress The address of the NFT manager contract
+   * @param nftTokenId The ID of the NFT
+   * @param stableAmounts The amounts of stablecoins spent on the NFT
+   *                      (0 = DAI, 1 = USDC, 2 = USDT)
+   * @param baseTokenAmount The amount of base tokens spent on the NFT
+   * @param baseTokenShare The amount of base tokens in the NFT
+   * @param assetTokenShare The amount of asset tokens in the NFT
+   * @param liquidityAmount The amount of liquidity created
+   */
+  event NFTMinted(
+    address indexed sender,
+    address indexed recipient,
+    address nftAddress,
+    uint256 nftTokenId,
+    uint256[3] stableAmounts,
+    uint256 baseTokenAmount,
+    uint256 baseTokenShare,
+    uint256 assetTokenShare,
+    uint256 liquidityAmount
+  );
+
+  /**
+   * @dev Emitted when fees are collected from a Uniswap V3 LP NFT
+   *
+   * @param sender The sender of the collection requiest
+   * @param recipient The address of the recipient of the LP NFT
+   * @param nftAddress The address of the NFT manager contract
+   * @param nftTokenId The ID of the NFT
+   * @param liquidityAmount The amount of liquidity in the NFT before collection
+   * @param baseTokensCollected The amount of base token fees collected
+   * @param assetTokensCollected The amount of asset token fees collected
+   * @param stableIndex The index of the stablecoin to collect fees into
+   *                    (0 = DAI, 1 = USDC, 2 = USDT)
+   * @param stablesReturned The amount of stablecoins returned to the recipient
+   */
+  event NFTCollected(
+    address indexed sender,
+    address indexed recipient,
+    address nftAddress,
+    uint256 nftTokenId,
+    uint256 liquidityAmount,
+    uint256 baseTokensCollected,
+    uint256 assetTokensCollected,
+    uint256 stableIndex,
+    uint256 stablesReturned
+  );
+
+  //////////////////////////////////////////////////////////////////////////////
+  // External interface for adding liquidity
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Mints a Uniswap V3 LP NFT and deposits liquidity into the pool
+   *
+   * A one-sided swap will occur, allowing unequal amounts of tokens to be
+   * deposited. The direction of the swap is determined by which of the
+   * swap amounts is non-zero.
+   *
+   * @param stableAmounts The amounts of underlying stablecoins to deposit
+   *                      (0 = DAI, 1 = USDC, 2 = USDT)
+   * @param assetSwapAmount The amount of the asset token to swap for the base
+   *                        token
+   * @param baseTokenAmount The amount of the base token to deposit
+   * @param baseSwapAmount The amount of the base token to swap for the asset
+   *                       token
+   * @param recipient The recient of the LP NFT
+   *
+   * @return nftTokenId The ID of the minted NFT
+   */
+  function mintNFT(
+    uint256[3] memory stableAmounts,
+    uint256 assetSwapAmount,
+    uint256 baseTokenAmount,
+    uint256 baseSwapAmount,
+    address recipient
+  ) external virtual returns (uint256 nftTokenId);
+
+  /**
+   * @dev Mints an LP NFT and deposits liquidity into the pool using stablecoins
+   *
+   * @param stableAmounts The amounts of stablecoins to use
+   * @param recipient The recipient of the LP NFT
+   *
+   * @return nftTokenId The ID of the minted NFT
+   */
+  function mintNFTWithStables(
+    uint256[3] memory stableAmounts,
+    address recipient
+  ) external virtual returns (uint256 nftTokenId);
+
+  /**
+   * @dev Mints an LP NFT and deposits liquidity into the pool using base tokens
+   *
+   * @param baseTokenAmount The amounts of base tokens to deposit
+   * @param recipient The recipient of the LP NFT
+   *
+   * @return nftTokenId The ID of the minted NFT
+   */
+  function mintNFTWithBaseToken(
+    uint256 baseTokenAmount,
+    address recipient
+  ) external virtual returns (uint256 nftTokenId);
+
+  /**
+   * @dev Mints an LP NFT and deposits liquidity into the pool using a single
+   * stablecoin
+   *
+   * @param stableIndex The index of the stablecoin to use
+   *                    (0 = DAI, 1 = USDC, 2 = USDT)
+   * @param stableAmount The amount of the stablecoin to use
+   *
+   * @return nftTokenId The ID of the minted NFT
+   */
+  function mintNFTOneStable(
+    uint256 stableIndex,
+    uint256 stableAmount
+  ) external virtual returns (uint256 nftTokenId);
+
+  /**
+   * @dev Mints a Uniswap V3 LP NFT and deposits liquidity into the pool
+   * without performing a one-sided token swap
+   *
+   * @param stableAmounts The amounts of underlying stablecoins to deposit
+   *                      (0 = DAI, 1 = USDC, 2 = USDT)
+   * @param baseTokenAmount The amount of the base token to deposit
+   * @param recipient The recient of the LP NFT
+   *
+   * @return nftTokenId The ID of the minted NFT
+   */
+  function mintNFTImbalance(
+    uint256[3] memory stableAmounts,
+    uint256 baseTokenAmount,
+    address recipient
+  ) external virtual returns (uint256 nftTokenId);
+
+  //////////////////////////////////////////////////////////////////////////////
+  // External interface for removing liquidity
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Collects the fees from an LP NFT and returns the underlying
+   * stablecoins and LP NFT to the recipient
+   *
+   * @param nftTokenId The ID of the LP NFT
+   * @param stableIndex The index of the stablecoin to receive
+   *                    (0 = DAI, 1 = USDC, 2 = USDT)
+   * @param recipient The recipient of the fees and the LP NFT
+   *
+   * @return stablesReturned The amount of stablecoins returned to the recipient
+   */
+  function collectFromNFT(
+    uint256 nftTokenId,
+    uint256 stableIndex,
+    address recipient
+  ) external virtual returns (uint256 stablesReturned);
+
+  /**
+   * @dev Collects everything and returns the LP NFT in one transaction
+   *
+   * @param nftTokenId The ID of the LP NFT
+   * @param stableIndex The index of the stablecoin to receive
+   *                    (0 = DAI, 1 = USDC, 2 = USDT)
+   *
+   * @return stablesReturned The amount of stablecoins returned to the sender
+   */
+  function exitOneStable(
+    uint256 nftTokenId,
+    uint256 stableIndex
+  ) external virtual returns (uint256 stablesReturned);
+}

--- a/contracts/src/interfaces/token/routes/IUniV3Staker.sol
+++ b/contracts/src/interfaces/token/routes/IUniV3Staker.sol
@@ -1,0 +1,274 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/contracts
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+pragma solidity 0.8.16;
+
+/**
+ * @dev Token router to liquidity to the Uniswap V3 pool in exchange for an
+ * LP NFT
+ */
+abstract contract IUniV3Staker {
+  //////////////////////////////////////////////////////////////////////////////
+  // Events
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Emitted when a new incentive is created
+   *
+   * @param creator The address of the creator
+   * @param reward The reward amount
+   * @param startTime The start time of the incentive
+   * @param endTime The end time of the incentive
+   * @param refundee The incentive's refundee address
+   */
+  event IncentiveCreated(
+    address indexed creator,
+    uint256 reward,
+    uint256 startTime,
+    uint256 endTime,
+    address indexed refundee
+  );
+
+  /**
+   * @dev Emitted when a Uniswap V3 LP NFT is staked
+   *
+   * @param sender The sender of the underlying stablecoins
+   * @param recipient The address of the recipient of the LP NFT
+   * @param nftAddress The address of the NFT manager contract
+   * @param nftTokenId The ID of the NFT
+   * @param stableAmounts The amounts of stablecoins spent on the NFT
+   *                      (0 = DAI, 1 = USDC, 2 = USDT)
+   * @param baseTokenAmount The amount of base tokens spent on the NFT
+   */
+  event NFTStaked(
+    address indexed sender,
+    address indexed recipient,
+    address nftAddress,
+    uint256 nftTokenId,
+    uint256[3] stableAmounts,
+    uint256 baseTokenAmount
+  );
+
+  /**
+   * @dev Emitted when a Uniswap V3 LP NFT is unstaked
+   *
+   * @param sender The sender of the NFT
+   * @param nftAddress The address of the NFT manager contract
+   * @param nftTokenId The ID of the NFT
+   * @param rewardClaimed The amount of the base token claimed as a reward for
+   *                      staking the LP NFT
+   * @param stableIndex The index of the stablecoin to receive
+   *                    (0 = DAI, 1 = USDC, 2 = USDT)
+   * @param stablesReturned The amount of stablecoins returned to the recipient
+   */
+  event NFTUnstaked(
+    address indexed sender,
+    address indexed recipient,
+    address nftAddress,
+    uint256 nftTokenId,
+    uint256 rewardClaimed,
+    uint256 stableIndex,
+    uint256 stablesReturned
+  );
+
+  //////////////////////////////////////////////////////////////////////////////
+  // External interface for staking LP NFTs
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Mints and stakes a Uniswap V3 LP NFT, depositing stablecoins
+   *
+   * @param stableAmounts The amounts of underlying stablecoins to deposit
+   *                      (0 = DAI, 1 = USDC, 2 = USDT)
+   * @param recipient The recient of the LP NFT
+   *
+   * @return nftTokenId The ID of the minted LP NFT
+   */
+  function stakeNFTWithStables(
+    uint256[3] memory stableAmounts,
+    address recipient
+  ) external virtual returns (uint256 nftTokenId);
+
+  /**
+   * @dev Mints and stakes a Uniswap V3 LP NFT using a single stablecoin
+   *
+   * @param stableIndex The index of the stablecoin to use
+   *                    (0 = DAI, 1 = USDC, 2 = USDT)
+   * @param stableAmount The amount of the stablecoin to use
+   *
+   * @return nftTokenId The ID of the minted LP NFT
+   */
+  function stakeNFTOneStable(
+    uint256 stableIndex,
+    uint256 stableAmount
+  ) external virtual returns (uint256 nftTokenId);
+
+  /**
+   * @dev Mints and stakes a Uniswap V3 LP NFT, depositing base tokens
+   *
+   * @param baseTokenAmount The amount of the base token to deposit, or 0 to
+   *                        swap half the stable amounts into the base token
+   * @param recipient The recient of the LP NFT
+   *
+   * @return nftTokenId The ID of the minted LP NFT
+   */
+  function stakeNFTWithBaseToken(
+    uint256 baseTokenAmount,
+    address recipient
+  ) external virtual returns (uint256 nftTokenId);
+
+  /**
+   * @dev Mints and stakes a Uniswap V3 LP NFT without performing a one-sided
+   * token swap
+   *
+   * @param stableAmounts The amounts of underlying stablecoins to deposit
+   *                      (0 = DAI, 1 = USDC, 2 = USDT)
+   * @param baseTokenAmount The amount of the base token to deposit, or 0 to
+   *                        swap half the stable amounts into the base token
+   * @param recipient The recient of the LP NFT
+   *
+   * @return nftTokenId The ID of the minted LP NFT
+   */
+  function stakeNFTImbalance(
+    uint256[3] memory stableAmounts,
+    uint256 baseTokenAmount,
+    address recipient
+  ) external virtual returns (uint256 nftTokenId);
+
+  //////////////////////////////////////////////////////////////////////////////
+  // External interface for unstaking LP NFTs
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Unstakes an LP NFT and returns the underlying liquidity as a
+   * stablecoin
+   *
+   * Instead of burning the empty NFT, it is transfered to the recipient as a
+   * keepsake.
+   *
+   * @param nftTokenId The ID of the LP NFT
+   * @param stableIndex The index of the stablecoin to receive
+   *                    (0 = DAI, 1 = USDC, 2 = USDT)
+   * @param recipient The recipient of the stablecoin
+   *
+   * @return stablesReturned The total amount of stablecoins returned to the
+   *                         recipient
+   */
+  function unstakeNFT(
+    uint256 nftTokenId,
+    uint256 stableIndex,
+    address recipient
+  ) external virtual returns (uint256 stablesReturned);
+
+  /**
+   * @dev Collects everything and returns the empty LP NFT in one transaction
+   *
+   * @param nftTokenId The ID of the LP NFT
+   * @param stableIndex The index of the stablecoin to receive
+   *                    (0 = DAI, 1 = USDC, 2 = USDT)
+   *
+   * @return stablesReturned The total amount of stablecoins returned to the
+   *                         recipient
+   */
+  function exitOneStable(
+    uint256 nftTokenId,
+    uint256 stableIndex
+  ) external virtual returns (uint256 stablesReturned);
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Public accessors
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Get the staking incentive
+   *
+   * @return totalRewardUnclaimed The amount of reward token not yet claimed by
+   *                              users
+   * @return totalSecondsClaimedX128 Total liquidity-seconds claimed,
+   *                                 represented as a UQ32.128
+   * @return numberOfStakes The count of deposits that are currently staked for
+   *                        the incentive
+   */
+  function getIncentive()
+    external
+    view
+    virtual
+    returns (
+      uint256 totalRewardUnclaimed,
+      uint160 totalSecondsClaimedX128,
+      uint96 numberOfStakes
+    );
+
+  /**
+   * @dev Get information about a deposited LP NFT
+   *
+   * @return owner_ The owner of the deposited LP NFT
+   * @return numberOfStakes Counter of how many incentives for which the
+   *                        liquidity is staked
+   * @return tickLower The lower tick of the range
+   * @return tickUpper The upper tick of the range
+   */
+  function getDeposit(
+    uint256 tokenId
+  )
+    external
+    view
+    virtual
+    returns (
+      address owner_,
+      uint48 numberOfStakes,
+      int24 tickLower,
+      int24 tickUpper
+    );
+
+  /**
+   * @dev Get information about a staked liquidity NFT
+   *
+   * @param tokenId The ID of the staked token
+   *
+   * @return secondsPerLiquidityInsideInitialX128 secondsPerLiquidity
+   *                                              represented as a UQ32.128
+   * @return liquidity The amount of liquidity in the NFT as of the last time
+   *                   the rewards were computed
+   */
+  function getStake(
+    uint256 tokenId
+  )
+    external
+    view
+    virtual
+    returns (uint160 secondsPerLiquidityInsideInitialX128, uint128 liquidity);
+
+  /**
+   * @dev Returns amounts of reward tokens owed to a given address according
+   * to the last time all stakes were updated
+   *
+   * @param owner_ The owner for which the rewards owed are checked
+   *
+   * @return rewardsOwed The amount of the reward token claimable by the owner
+   */
+  function getRewardsOwed(
+    address owner_
+  ) external view virtual returns (uint256 rewardsOwed);
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Public mutators
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Calculates the reward amount that will be received for the given stake
+   *
+   * @param tokenId The ID of the token
+   *
+   * @return reward The reward accrued to the NFT for the given incentive thus
+   *                far
+   */
+  function getRewardInfo(
+    uint256 tokenId
+  ) external virtual returns (uint256 reward, uint160 secondsInsideX128);
+}

--- a/contracts/src/interfaces/token/routes/IUniV3Swapper.sol
+++ b/contracts/src/interfaces/token/routes/IUniV3Swapper.sol
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/contracts
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+pragma solidity 0.8.16;
+
+/**
+ * @dev Token router to swap between the base token and a yielding asset token
+ */
+abstract contract IUniV3Swapper {
+  //////////////////////////////////////////////////////////////////////////////
+  // Events
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Emitted when base tokens are purchased on Uniswap
+   *
+   * @param sender The sender of the underlying stablecoins
+   * @param recipient The address of the recipient of the base token
+   * @param stableAmounts The amounts of stablecoins to spend
+   *                      (0 = DAI, 1 = USDC, 2 = USDT)
+   * @param assetTokenAmount The amount of asset tokens being spent
+   * @param baseTokenReturned The amount of base tokens received
+   */
+  event TokensBought(
+    address indexed sender,
+    address indexed recipient,
+    uint256[3] stableAmounts,
+    uint256 assetTokenAmount,
+    uint256 baseTokenReturned
+  );
+
+  /**
+   * @dev Emitted when base tokens are sold on Uniswap for asset tokens
+   *
+   * @param sender The sender of the base token
+   * @param recipient The address of the recipient of the underlying stablecoins
+   * @param baseTokenAmount The amount of base tokens spent
+   * @param assetTokensReturned The amount of asset tokens returned to the
+   *                            recipient
+   *
+   * Note that due to dust, assetTokensReturned may be more than
+   * assetTokenAmount.
+   */
+  event TokensSoldForAsset(
+    address indexed sender,
+    address indexed recipient,
+    uint256 baseTokenAmount,
+    uint256 assetTokensReturned
+  );
+
+  /**
+   * @dev Emitted when base tokens are sold on Uniswap for stablecoins
+   *
+   * @param sender The sender of the base token
+   * @param recipient The address of the recipient of the underlying stablecoins
+   * @param stableIndex The index of the stablecoin to receive
+   *                    (0 = DAI, 1 = USDC, 2 = USDT)
+   * @param baseTokenSpent The amount of base tokens spent
+   * @param assetTokensUnstaked The amount of asset tokens unstaked from the
+   *                            Curve Aave pool
+   * @param stablesReturned The amount of stablecoins returned to the recipient
+   *
+   * Note that due to dust, stablesReturned may be more than stablesUnstaked.
+   */
+  event TokensSoldForStable(
+    address indexed sender,
+    address indexed recipient,
+    uint256 stableIndex,
+    uint256 baseTokenSpent,
+    uint256 assetTokensUnstaked,
+    uint256 stablesReturned
+  );
+
+  //////////////////////////////////////////////////////////////////////////////
+  // External interface for swapping into the base token
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Swaps the underlying stablecoins or the asset token for the base token
+   *
+   * @param stableAmounts The amounts of underlying stablecoins to include in
+   *                      the swap (0 = DAI, 1 = USDC, 2 = USDT)
+   * @param assetTokenAmount The ammount of the asset tokens to include in the swap
+   * @param recipient The recient of the swapped tokens
+   *
+   * @return baseTokensReturned The amount of base tokens sent to the recipient
+   */
+  function buyTokens(
+    uint256[3] memory stableAmounts,
+    uint256 assetTokenAmount,
+    address recipient
+  ) external virtual returns (uint256 baseTokensReturned);
+
+  /**
+   * @dev Swaps a single underlying stablecoin for the base token
+   *
+   * @param stableIndex The index of the stablecoin to swap
+   *                    (0 = DAI, 1 = USDC, 2 = USDT)
+   * @param stableAmount The amount of the underlying stablecoin to swap
+   *
+   * @return baseTokensReturned The amount of base tokens sent to the sender
+   */
+  function buyTokensOneStable(
+    uint256 stableIndex,
+    uint256 stableAmount
+  ) external virtual returns (uint256 baseTokensReturned);
+
+  //////////////////////////////////////////////////////////////////////////////
+  // External interface for swapping out of the base token
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Swaps the base token for the asset token
+   *
+   * @param baseTokenAmount The amount of the base token to swap
+   * @param recipient The recient of the swapped tokens
+   *
+   * @return assetTokensReturned The amount of asset tokens sent to the
+   *                             recipient
+   */
+  function sellTokensForAsset(
+    uint256 baseTokenAmount,
+    address recipient
+  ) external virtual returns (uint256 assetTokensReturned);
+
+  /**
+   * @dev Swaps the base token for the underlying stablecoin
+   *
+   * @param baseTokenAmount The amount of the base token to swap
+   * @param stableIndex The index of the stablecoin to swap
+   *                    (0 = DAI, 1 = USDC, 2 = USDT)
+   * @param recipient The recient of the stab
+   *
+   * @return stablesReturned The amount of stablecoins returned to recipient
+   */
+  function sellTokensForStable(
+    uint256 baseTokenAmount,
+    uint256 stableIndex,
+    address recipient
+  ) external virtual returns (uint256 stablesReturned);
+
+  /**
+   * @dev Swap everything to a single underlying stablecoin in one function
+   * call
+   *
+   * @param stableIndex The index of the stablecoin to unstake
+   * ]                  (0 = DAI, 1 = USDC, 2 = USDT)
+   *
+   * @return stablesReturned The amount of stablecoins returned
+   */
+  function exitOneStable(
+    uint256 stableIndex
+  ) external virtual returns (uint256 stablesReturned);
+}

--- a/contracts/src/token/CHESS.sol
+++ b/contracts/src/token/CHESS.sol
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/contracts
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+pragma solidity 0.8.16;
+
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/**
+ * @dev Implementation of the https://eips.ethereum.org/EIPS/eip-20[ERC20] Token
+ * Standard
+ */
+contract CHESS is AccessControl, ERC20 {
+  //////////////////////////////////////////////////////////////////////////////
+  // Constants
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev The ERC 20 token name used by wallets to identify the token
+   */
+  string private constant TOKEN_NAME = "Ultrachess Token";
+
+  /**
+   * @dev The ERC 20 token symbol used as an abbreviation of the token, such
+   * as BTC, ETH, AUG or SJCX.
+   */
+  string private constant TOKEN_SYMBOL = "CHESS";
+
+  uint8 public constant DECIMALS = 18;
+
+  uint256 public constant INITIAL_SUPPLY = 10_000 * (10 ** uint256(DECIMALS)); // 10,000 tokens
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Initialization
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Initializes the ERC-20 token with a name and symbol
+   *
+   * @param owner_ The owner of the token
+   */
+  constructor(address owner_) ERC20(TOKEN_NAME, TOKEN_SYMBOL) {
+    // Validate parameters
+    require(owner_ != address(0), "Invalid owner");
+
+    // Initialize {AccessControl}
+    _setupRole(DEFAULT_ADMIN_ROLE, owner_);
+
+    // Mint the initial supply to the owner
+    _mint(owner_, INITIAL_SUPPLY);
+  }
+}

--- a/contracts/src/token/LpSft.sol
+++ b/contracts/src/token/LpSft.sol
@@ -1,0 +1,196 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/contracts
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+pragma solidity 0.8.16;
+
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {ERC1155} from "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+
+import {INonfungiblePositionManager} from "../../interfaces/uniswap-v3-periphery/INonfungiblePositionManager.sol";
+
+import {ERC1155Enumberable} from "./extensions/ERC1155Enumerable.sol";
+
+/**
+ * @dev Implementation of the https://eips.ethereum.org/EIPS/eip-1155[ERC1155]
+ * Semi-fungible Token Standard
+ */
+contract LpSft is AccessControl, ERC1155Enumberable {
+  //////////////////////////////////////////////////////////////////////////////
+  // Roles
+  //////////////////////////////////////////////////////////////////////////////
+
+  // Only ISSUERS can mint and destroy tokens
+  bytes32 public constant ISSUER_ROLE = "ISSUER_ROLE";
+
+  //////////////////////////////////////////////////////////////////////////////
+  // State
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev The Uniswap V3 NFT manager
+   */
+  INonfungiblePositionManager public immutable uniswapV3NftManager;
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Initialization
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Initializes the ERC-1155 contract
+   *
+   * @param owner_ The owner of the ERC-1155 contract
+   * @param uniswapV3NftManager_ The Uniswap V3 NFT manager
+   */
+  constructor(address owner_, address uniswapV3NftManager_) ERC1155("") {
+    // Validate parameters
+    require(owner_ != address(0), "Invalid owner");
+    require(uniswapV3NftManager_ != address(0), "Invalid mgr");
+
+    // Initialize {AccessControl}
+    _grantRole(DEFAULT_ADMIN_ROLE, owner_);
+
+    // Initialize state
+    uniswapV3NftManager = INonfungiblePositionManager(uniswapV3NftManager_);
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Implementation of {IERC165} via {AccessControl} and {ERC1155Enumerable}
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev See {IERC165-supportsInterface}
+   */
+  function supportsInterface(
+    bytes4 interfaceId
+  ) public view override(AccessControl, ERC1155) returns (bool) {
+    return
+      AccessControl.supportsInterface(interfaceId) ||
+      ERC1155.supportsInterface(interfaceId);
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Implementation of {IERC1155MetadataURI} via {ERC1155}
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev See {IERC1155MetadataURI-uri}
+   */
+  function uri(
+    uint256 sftTokenId
+  ) public view override returns (string memory) {
+    return uniswapV3NftManager.tokenURI(sftTokenId);
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Issuer functions
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Mints a new LP SFT
+   *
+   * @param account The account to mint an LP SFT to
+   * @param sftTokenId The token ID of the minted LP SFT
+   */
+  function mint(address account, uint256 sftTokenId) external {
+    // Validate access
+    require(hasRole(ISSUER_ROLE, _msgSender()), "Not issuer");
+
+    // Validate parameters
+    require(account != address(0), "Invalid account");
+
+    // Call ancestor
+    _mint(account, sftTokenId, 1, "");
+  }
+
+  /**
+   * @dev Mints a batch of LP SFTs
+   *
+   * @param account The account to mint SFTs to
+   * @param sftTokenIds The token IDs of the minted SFTs
+   *
+   * Note: This function does not place a limit on the number of LP SFTs that
+   * can be minted in a single transaction. The number of LP SFTs to mint can
+   * exceed the block gas limit, denying the transaction from completing.
+   */
+  function mintBatch(address account, uint256[] memory sftTokenIds) external {
+    // Validate access
+    require(hasRole(ISSUER_ROLE, _msgSender()), "Not issuer");
+
+    // Validate parameters
+    require(account != address(0), "Invalid account");
+    require(sftTokenIds.length > 0, "No IDs");
+
+    // Translate parameters
+    uint256[] memory tokenAmounts = _getAmountArray(sftTokenIds.length);
+
+    // Call ancestor
+    _mintBatch(account, sftTokenIds, tokenAmounts, "");
+  }
+
+  /**
+   * @dev Burns an existing LP SFT
+   *
+   * @param account The account to burn an LP SFT from
+   * @param sftTokenId The token ID of the LP SFT to burn
+   */
+  function burn(address account, uint256 sftTokenId) external {
+    // Validate access
+    require(hasRole(ISSUER_ROLE, _msgSender()), "Not issuer");
+
+    // Validate parameters
+    require(account != address(0), "Invalid account");
+
+    // Call ancestor
+    _burn(account, sftTokenId, 1);
+  }
+
+  /**
+   * @dev Burns a batch of existing LP SFTs
+   *
+   * @param account The account to burn LP SFTs from
+   * @param sftTokenIds The token IDs of the LP SFTs to burn
+   *
+   * Note: This function does not place a limit on the number of LP SFTs that
+   * can be burned in a single transaction. The number of LP SFTs to burn can
+   * exceed the block gas limit, denying the transaction from completing.
+   */
+  function burnBatch(address account, uint256[] memory sftTokenIds) external {
+    // Validate access
+    require(hasRole(ISSUER_ROLE, _msgSender()), "Not issuer");
+
+    // Validate parameters
+    require(account != address(0), "Invalid account");
+    require(sftTokenIds.length > 0, "No IDs");
+
+    // Translate parameters
+    uint256[] memory tokenAmounts = _getAmountArray(sftTokenIds.length);
+
+    // Call ancestor
+    _burnBatch(account, sftTokenIds, tokenAmounts);
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Private functions
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Get an amounts array suitable for NFTs (where the total supply of
+   * each token is 1)
+   */
+  function _getAmountArray(
+    uint256 tokenCount
+  ) private pure returns (uint256[] memory) {
+    uint256[] memory array = new uint256[](tokenCount);
+
+    for (uint256 i = 0; i < tokenCount; i++) {
+      array[i] = 1;
+    }
+
+    return array;
+  }
+}

--- a/contracts/src/token/Ultra3CRV.sol
+++ b/contracts/src/token/Ultra3CRV.sol
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/contracts
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+pragma solidity 0.8.16;
+
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/**
+ * @dev Implementation of the https://eips.ethereum.org/EIPS/eip-20[ERC20] Token
+ * Standard
+ */
+contract Ultra3CRV is AccessControl, ERC20 {
+  //////////////////////////////////////////////////////////////////////////////
+  // Constants
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev The ERC 20 token name used by wallets to identify the token
+   */
+  string private constant TOKEN_NAME = "Ultrachess staked am3CRV";
+
+  /**
+   * @dev The ERC 20 token symbol used as an abbreviation of the token, such
+   * as BTC, ETH, AUG or SJCX.
+   */
+  string private constant TOKEN_SYMBOL = "ultra3CRV";
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Roles
+  //////////////////////////////////////////////////////////////////////////////
+
+  // Only ISSUERS can mint and destroy tokens
+  bytes32 public constant ISSUER_ROLE = "ISSUER_ROLE";
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Initialization
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Initializes the ERC-20 token with a name and symbol
+   *
+   * @param owner_ The owner of the token
+   */
+  constructor(address owner_) ERC20(TOKEN_NAME, TOKEN_SYMBOL) {
+    // Validate parameters
+    require(owner_ != address(0), "Invalid owner");
+
+    // Initialize {AccessControl}
+    _grantRole(DEFAULT_ADMIN_ROLE, owner_);
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Issuer functions
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Mints new tokens
+   *
+   * @param account The account to mint tokens to
+   * @param amount The amount of tokens to mint
+   */
+  function mint(address account, uint256 amount) public {
+    // Validate access
+    require(hasRole(ISSUER_ROLE, _msgSender()), "Not issuer");
+
+    // Validate parameters
+    require(account != address(0), "Invalid account");
+
+    // Mint tokens
+    _mint(account, amount);
+  }
+
+  /**
+   * @dev Burns tokens
+   *
+   * @param account The account to burn tokens from
+   * @param amount The amount of tokens to burn
+   */
+  function burn(address account, uint256 amount) public {
+    // Validate access
+    require(hasRole(ISSUER_ROLE, _msgSender()), "Not issuer");
+
+    // Validate parameters
+    require(account != address(0), "Invalid account");
+
+    // Burn tokens
+    _burn(account, amount);
+  }
+}

--- a/contracts/src/token/extensions/ERC1155Enumerable.sol
+++ b/contracts/src/token/extensions/ERC1155Enumerable.sol
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/contracts
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+pragma solidity 0.8.16;
+
+import {ERC1155} from "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
+/**
+ * @dev Implementation of the https://eips.ethereum.org/EIPS/eip-1155[ERC1155]
+ * Semi-fungible Token Standard
+ *
+ * This contract is analogous to the OpenZeppelin ERC721Enumerable contract. It
+ * enforces the constraint that all SFTs are NFTs (they are unique with a total
+ * supply of 1).
+ */
+abstract contract ERC1155Enumberable is ERC1155 {
+  using EnumerableSet for EnumerableSet.UintSet;
+
+  //////////////////////////////////////////////////////////////////////////////
+  // State
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Mapping from token ID to owner
+   */
+  mapping(uint256 => address) private _tokenOwner;
+
+  /**
+   * @dev Mapping from owner to owned token IDs
+   */
+  mapping(address => EnumerableSet.UintSet) private _ownedTokens;
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Implementation of {ERC1155}
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev See {ERC1155-_beforeTokenTransfer}
+   */
+  function _beforeTokenTransfer(
+    address,
+    address from,
+    address to,
+    uint256[] memory sftTokenIds,
+    uint256[] memory sftTokenAmounts,
+    bytes memory
+  ) internal override {
+    // Translate parameters
+    uint256 tokenCount = sftTokenIds.length;
+
+    for (uint256 i = 0; i < tokenCount; i++) {
+      // Translate parameters
+      uint256 sftTokenId = sftTokenIds[i];
+
+      // Validate parameters
+      require(sftTokenAmounts[i] == 1, "Invalid amount");
+
+      // Handle minting
+      if (from == address(0)) {
+        // Validate state
+        require(_tokenOwner[sftTokenId] == address(0), "Already minted");
+
+        // Update state
+        _tokenOwner[sftTokenId] = to;
+        require(_ownedTokens[to].add(sftTokenId), "Already added");
+      }
+
+      // Handle transfer
+      if (from != address(0) && to != address(0)) {
+        // Validate state
+        require(_tokenOwner[sftTokenId] == from, "Invalid owner");
+
+        // Update state
+        _tokenOwner[sftTokenId] = to;
+        require(_ownedTokens[from].remove(sftTokenId), "Already removed");
+        require(_ownedTokens[to].add(sftTokenId), "Already added");
+      }
+
+      // Handle burning
+      if (to == address(0)) {
+        // Validate state
+        require(_tokenOwner[sftTokenId] == from, "Invalid owner");
+
+        // Update state
+        _tokenOwner[sftTokenId] = address(0);
+        require(_ownedTokens[from].remove(sftTokenId), "Already removed");
+      }
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // External accessors
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Returns the owner of the NFT specified by `tokenId`
+   *
+   * @param stfTokenId The ID of the LP SFT token
+   *
+   * @return owner_ The owner of the token, or `address(0)` if the token does
+   *                not exist
+   */
+  function ownerOf(uint256 stfTokenId) public view returns (address owner_) {
+    // Read state
+    owner_ = _tokenOwner[stfTokenId];
+
+    return owner_;
+  }
+
+  /**
+   * @dev Return all token IDs owned by account
+   *
+   * @param account The account to query
+   *
+   * @return sftTokenIds The token IDs owned by the account
+   */
+  function getTokenIds(
+    address account
+  ) public view returns (uint256[] memory sftTokenIds) {
+    // Load state
+    EnumerableSet.UintSet storage ownedTokens = _ownedTokens[account];
+
+    // Read state
+    sftTokenIds = ownedTokens.values();
+
+    return sftTokenIds;
+  }
+}

--- a/contracts/src/token/routes/CurveAavePooler.sol
+++ b/contracts/src/token/routes/CurveAavePooler.sol
@@ -1,0 +1,252 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/contracts
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+pragma solidity 0.8.16;
+
+import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Context} from "@openzeppelin/contracts/utils/Context.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
+import {StableSwapAave} from "../../../interfaces/curve/StableSwapAave.sol";
+
+import {ICurveAavePooler} from "../../interfaces/token/routes/ICurveAavePooler.sol";
+
+/**
+ * @dev See {ICurveAavePooler}
+ */
+contract CurveAavePooler is ICurveAavePooler, Context, ReentrancyGuard {
+  using SafeERC20 for IERC20;
+
+  //////////////////////////////////////////////////////////////////////////////
+  // State
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev The upstream Curve Aave pool contract
+   */
+  StableSwapAave public immutable curveAavePool;
+
+  // Public token addresses
+  IERC20 public immutable daiToken;
+  IERC20 public immutable usdcToken;
+  IERC20 public immutable usdtToken;
+  IERC20 public immutable curveAaveLpToken;
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Initialization
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Initializes the contract
+   *
+   * @param curveAavePool_ The address of Curve's Aave stable swap contract
+   */
+  constructor(address curveAavePool_) {
+    // Validate parameters
+    require(curveAavePool_ != address(0), "Invalid pool");
+
+    // Read external contracts
+    address diaToken_ = StableSwapAave(curveAavePool_).underlying_coins(0);
+    address usdcToken_ = StableSwapAave(curveAavePool_).underlying_coins(1);
+    address usdtToken_ = StableSwapAave(curveAavePool_).underlying_coins(2);
+    address curveAaveLpToken_ = StableSwapAave(curveAavePool_).lp_token();
+
+    // Validate external contracts
+    require(diaToken_ != address(0), "Invalid curve DAI");
+    require(usdcToken_ != address(0), "Invalid curve USDC");
+    require(usdtToken_ != address(0), "Invalid curve USDT");
+    require(curveAaveLpToken_ != address(0), "Invalid curve LP");
+
+    // Initialize state
+    curveAavePool = StableSwapAave(curveAavePool_);
+    daiToken = IERC20(diaToken_);
+    usdcToken = IERC20(usdcToken_);
+    usdtToken = IERC20(usdtToken_);
+    curveAaveLpToken = IERC20(curveAaveLpToken_);
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Implementation of {ICurveAavePooler}
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev See {ICurveAavePooler-addLiquidity}
+   */
+  // slither-disable-next-line reentrancy-events
+  function addLiquidity(
+    uint256[3] memory stableAmounts,
+    uint256 minMintAmount,
+    address recipient
+  ) public override nonReentrant returns (uint256 lpTokenAmount) {
+    // Validate parameters
+    require(recipient != address(0), "Invalid recipient");
+
+    // Call external contracts
+    if (stableAmounts[0] > 0) {
+      daiToken.safeTransferFrom(_msgSender(), address(this), stableAmounts[0]);
+      daiToken.safeIncreaseAllowance(address(curveAavePool), stableAmounts[0]);
+    }
+    if (stableAmounts[1] > 0) {
+      usdcToken.safeTransferFrom(_msgSender(), address(this), stableAmounts[1]);
+      usdcToken.safeIncreaseAllowance(address(curveAavePool), stableAmounts[1]);
+    }
+    if (stableAmounts[2] > 0) {
+      usdtToken.safeTransferFrom(_msgSender(), address(this), stableAmounts[2]);
+      usdtToken.safeIncreaseAllowance(address(curveAavePool), stableAmounts[2]);
+    }
+
+    // Add liquidity to the pool
+    uint256 mintAmount = curveAavePool.add_liquidity(
+      stableAmounts,
+      minMintAmount,
+      true
+    );
+
+    // Transfer LP tokens to the recipient
+    curveAaveLpToken.safeTransfer(recipient, mintAmount);
+
+    // Dispatch event
+    // slither-disable-next-line reentrancy-events
+    emit LiquidityAdded(_msgSender(), recipient, stableAmounts, mintAmount);
+
+    return mintAmount;
+  }
+
+  /**
+   * @dev See {ICurveAavePooler-addLiquidityOneStable}
+   */
+  function addLiquidityOneStable(
+    uint256 stableIndex,
+    uint256 stableAmount
+  ) public override returns (uint256 lpTokenAmount) {
+    // Validate parameters
+    require(stableIndex <= 2, "Invalid token");
+
+    // Translate parameters
+    uint256[3] memory stableAmounts;
+    stableAmounts[stableIndex] = stableAmount;
+
+    // Add liquidity to the pool
+    lpTokenAmount = addLiquidity(stableAmounts, 0, _msgSender());
+
+    return lpTokenAmount;
+  }
+
+  /**
+   * @dev See {ICurveAavePooler-removeLiquidityOneStable}
+   */
+  // slither-disable-next-line reentrancy-events
+  function removeLiquidityOneStable(
+    uint256 lpTokenAmount,
+    uint256 stableIndex,
+    uint256 minTokenAmount,
+    address recipient
+  ) public override nonReentrant returns (uint256 stablesReturned) {
+    // Validate parameters
+    require(lpTokenAmount > 0, "Invalid amount");
+    require(stableIndex <= 2, "Invalid token");
+    require(recipient != address(0), "Invalid recipient");
+
+    // Call external contracts
+    curveAaveLpToken.safeTransferFrom(
+      _msgSender(),
+      address(this),
+      lpTokenAmount
+    );
+
+    curveAaveLpToken.safeIncreaseAllowance(
+      address(curveAavePool),
+      lpTokenAmount
+    );
+
+    // Remove the LP tokens from the pool
+    uint256 removedAmount = curveAavePool.remove_liquidity_one_coin(
+      lpTokenAmount,
+      SafeCast.toInt128(SafeCast.toInt256(stableIndex)),
+      minTokenAmount,
+      true
+    );
+
+    // Call external contracts
+    if (stableIndex == 0) {
+      daiToken.safeTransfer(recipient, removedAmount);
+    } else if (stableIndex == 1) {
+      usdcToken.safeTransfer(recipient, removedAmount);
+    } else if (stableIndex == 2) {
+      usdtToken.safeTransfer(recipient, removedAmount);
+    }
+
+    // Dispatch event
+    // slither-disable-next-line reentrancy-events
+    emit LiquidityRemovedOneStable(
+      _msgSender(),
+      recipient,
+      lpTokenAmount,
+      stableIndex,
+      removedAmount
+    );
+
+    return removedAmount;
+  }
+
+  /**
+   * @dev See {ICurveAavePooler-exitOneStable}
+   */
+  function exitOneStable(
+    uint256 stableIndex
+  ) public override returns (uint256 stablesReturned) {
+    // Read state
+    uint256 lpTokenAmount = curveAaveLpToken.balanceOf(_msgSender());
+
+    // Remove all liquidity
+    stablesReturned = removeLiquidityOneStable(
+      lpTokenAmount,
+      stableIndex,
+      0,
+      _msgSender()
+    );
+  }
+
+  /**
+   * @dev See {ICurveAavePooler-getVirtualPrice}
+   */
+  function getVirtualPrice()
+    public
+    view
+    override
+    returns (uint256 virtualPrice)
+  {
+    return curveAavePool.get_virtual_price();
+  }
+
+  /**
+   * @dev See {ICurveAavePooler-getLpAmount}
+   */
+  function getLpAmount(
+    uint256[3] memory stableAmounts,
+    bool isDeposit
+  ) public view override returns (uint256 mintAmount) {
+    return curveAavePool.calc_token_amount(stableAmounts, isDeposit);
+  }
+
+  /**
+   * @dev See {ICurveAavePooler-getStableAmount}
+   */
+  function getStableAmount(
+    uint256 lpTokenAmount,
+    uint256 stableIndex
+  ) public view override returns (uint256 stableAmount) {
+    return
+      curveAavePool.calc_withdraw_one_coin(
+        lpTokenAmount,
+        SafeCast.toInt128(SafeCast.toInt256(stableIndex))
+      );
+  }
+}

--- a/contracts/src/token/routes/CurveAaveStaker.sol
+++ b/contracts/src/token/routes/CurveAaveStaker.sol
@@ -1,0 +1,302 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/contracts
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+pragma solidity 0.8.16;
+
+import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Context} from "@openzeppelin/contracts/utils/Context.sol";
+
+import {LiquidityGauge} from "../../../interfaces/curve-dao/LiquidityGauge.sol";
+
+import {ICurveAaveStaker} from "../../interfaces/token/routes/ICurveAaveStaker.sol";
+
+import {Ultra3CRV} from "../Ultra3CRV.sol";
+import {CurveAavePooler} from "./CurveAavePooler.sol";
+
+/**
+ * @dev See {ICurveAaveStaker}
+ */
+contract CurveAaveStaker is ICurveAaveStaker, Context, ReentrancyGuard {
+  using SafeERC20 for IERC20;
+
+  //////////////////////////////////////////////////////////////////////////////
+  // State
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev The Ultrachess Curve Aave pooler contract
+   */
+  CurveAavePooler public immutable curveAavePooler;
+
+  /**
+   * @dev The upstream Curve Aave gauge contract
+   */
+  LiquidityGauge public immutable curveAaveGauge;
+
+  /**
+   * @dev The Ultrachess token representing am3CRV staked in the Curve Aave gauge
+   */
+  Ultra3CRV public immutable assetToken;
+
+  // Public token addresses
+  IERC20 public immutable daiToken;
+  IERC20 public immutable usdcToken;
+  IERC20 public immutable usdtToken;
+  IERC20 public immutable curveAaveLpToken;
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Initialization
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Initializes the contract
+   *
+   * @param curveAavePooler_ The address of our Curve Aave pooler contract
+   * @param curveAaveGauge_ The address of Curve's Aave gauge contract
+   * @param assetToken_ The token representing staked am3CRV
+   */
+  constructor(
+    address curveAavePooler_,
+    address curveAaveGauge_,
+    address assetToken_
+  ) {
+    // Validate parameters
+    require(curveAavePooler_ != address(0), "Invalid pooler");
+    require(curveAaveGauge_ != address(0), "Invalid gauge");
+    require(assetToken_ != address(0), "Invalid token");
+
+    // Validate external contracts
+    require(
+      address(CurveAavePooler(curveAavePooler_).daiToken()) != address(0),
+      "Invalid curve pooler DAI"
+    );
+    require(
+      address(CurveAavePooler(curveAavePooler_).usdcToken()) != address(0),
+      "Invalid curve pooler USDC"
+    );
+    require(
+      address(CurveAavePooler(curveAavePooler_).usdtToken()) != address(0),
+      "Invalid curve pooler USDT"
+    );
+    require(
+      address(CurveAavePooler(curveAavePooler_).curveAaveLpToken()) !=
+        address(0),
+      "Invalid curve pooler LP"
+    );
+
+    // Initialize state
+    curveAavePooler = CurveAavePooler(curveAavePooler_);
+    curveAaveGauge = LiquidityGauge(curveAaveGauge_);
+    assetToken = Ultra3CRV(assetToken_);
+    daiToken = CurveAavePooler(curveAavePooler_).daiToken();
+    usdcToken = CurveAavePooler(curveAavePooler_).usdcToken();
+    usdtToken = CurveAavePooler(curveAavePooler_).usdtToken();
+    curveAaveLpToken = CurveAavePooler(curveAavePooler_).curveAaveLpToken();
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Implementation of {ICurveAaveStaker}
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev See {ICurveAaveStaker-stakeTokens}
+   */
+  function stakeTokens(
+    uint256[3] memory stableAmounts,
+    address recipient
+  ) public override nonReentrant returns (uint256 assetTokenAmount) {
+    // Validate parameters
+    require(
+      stableAmounts[0] > 0 || stableAmounts[1] > 0 || stableAmounts[2] > 0,
+      "Requires nonzero amount"
+    );
+    require(recipient != address(0), "Invalid recipient");
+
+    // Call external contracts
+    if (stableAmounts[0] > 0) {
+      daiToken.safeTransferFrom(_msgSender(), address(this), stableAmounts[0]);
+      daiToken.safeIncreaseAllowance(
+        address(curveAavePooler),
+        stableAmounts[0]
+      );
+    }
+    if (stableAmounts[1] > 0) {
+      usdcToken.safeTransferFrom(_msgSender(), address(this), stableAmounts[1]);
+      usdcToken.safeIncreaseAllowance(
+        address(curveAavePooler),
+        stableAmounts[1]
+      );
+    }
+    if (stableAmounts[2] > 0) {
+      usdtToken.safeTransferFrom(_msgSender(), address(this), stableAmounts[2]);
+      usdtToken.safeIncreaseAllowance(
+        address(curveAavePooler),
+        stableAmounts[2]
+      );
+    }
+
+    // Add liquidity to the Curve Aave pool
+    uint256 lpTokensAdded = curveAavePooler.addLiquidity(
+      stableAmounts,
+      0,
+      address(this)
+    );
+
+    // Validate external contracts
+    require(lpTokensAdded > 0, "No LP tokens");
+
+    // Mint the recipient asset tokens redeemable for the LP tokens
+    // slither-disable-next-line reentrancy-benign
+    assetToken.mint(recipient, lpTokensAdded);
+
+    // Call external contracts
+    curveAaveLpToken.safeIncreaseAllowance(
+      address(curveAaveGauge),
+      lpTokensAdded
+    );
+    curveAaveGauge.deposit(lpTokensAdded);
+
+    // Dispatch event
+    // slither-disable-next-line reentrancy-events
+    emit GaugeStaked(_msgSender(), recipient, stableAmounts, lpTokensAdded);
+
+    // Return the gauge token amount
+    return lpTokensAdded;
+  }
+
+  /**
+   * @dev See {ICurveAaveStaker-stakeOneStable}
+   */
+  function stakeOneStable(
+    uint256 stableIndex,
+    uint256 stableAmount
+  ) public override returns (uint256 gaugeTokenAmount) {
+    // Validate parameters
+    require(stableIndex <= 2, "Invalid stable");
+    require(stableAmount > 0, "Invalid amount");
+
+    // Translate parameters
+    uint256[3] memory stableAmounts;
+    stableAmounts[stableIndex] = stableAmount;
+
+    // Stake stablecoin to the gauge
+    gaugeTokenAmount = stakeTokens(stableAmounts, _msgSender());
+
+    // Return the gauge token amount
+    return gaugeTokenAmount;
+  }
+
+  /**
+   * @dev See {ICurveAaveStaker-unstakeOneStable}
+   */
+  function unstakeOneStable(
+    uint256 assetTokenAmount,
+    uint256 stableIndex,
+    address recipient
+  ) public override nonReentrant returns (uint256 stablesReturned) {
+    // Validate parameters
+    require(stableIndex <= 2, "Invalid stable");
+    require(recipient != address(0), "Invalid recipient");
+
+    // Burn the asset tokens being redeemed for the LP tokens
+    assetToken.burn(_msgSender(), assetTokenAmount);
+
+    // Call external contracts
+    curveAaveGauge.withdraw(assetTokenAmount);
+
+    // Approve the Curve Aave pooler to spend the gauge shares
+    curveAaveLpToken.safeIncreaseAllowance(
+      address(curveAavePooler),
+      assetTokenAmount
+    );
+
+    // Remove liquidity from the Curve Aave pool
+    stablesReturned = curveAavePooler.removeLiquidityOneStable(
+      assetTokenAmount,
+      stableIndex,
+      0,
+      address(this)
+    );
+
+    // Call external contracts
+    if (stableIndex == 0) {
+      daiToken.safeTransfer(recipient, stablesReturned);
+    } else if (stableIndex == 1) {
+      usdcToken.safeTransfer(recipient, stablesReturned);
+    } else if (stableIndex == 2) {
+      usdtToken.safeTransfer(recipient, stablesReturned);
+    }
+
+    // Dispatch event
+    // slither-disable-next-line reentrancy-events
+    emit GaugeUnstakedOneStable(
+      _msgSender(),
+      recipient,
+      assetTokenAmount,
+      stableIndex,
+      stablesReturned
+    );
+
+    return stablesReturned;
+  }
+
+  /**
+   * @dev See {ICurveAaveStaker-exitOneStable}
+   */
+  function exitOneStable(
+    uint256 stableIndex
+  ) public override returns (uint256 stablesReturned) {
+    // Read state
+    uint256 gaugeTokenAmount = assetToken.balanceOf(_msgSender());
+
+    // Unstake everything
+    stablesReturned = unstakeOneStable(
+      gaugeTokenAmount,
+      stableIndex,
+      _msgSender()
+    );
+
+    return stablesReturned;
+  }
+
+  /**
+   * @dev See {ICurveAaveStaker-getVirtualPrice}
+   */
+  function getVirtualPrice()
+    public
+    view
+    override
+    returns (uint256 virtualPrice)
+  {
+    return curveAavePooler.getVirtualPrice();
+  }
+
+  /**
+   * @dev See {ICurveAaveStaker-getAssetAmount}
+   */
+  function getAssetAmount(
+    uint256[3] memory stableAmounts,
+    bool isDeposit
+  ) public view override returns (uint256 assetAmount) {
+    // LP is staked 1:1 for asset
+    return curveAavePooler.getLpAmount(stableAmounts, isDeposit);
+  }
+
+  /**
+   * @dev See {ICurveAaveStaker-getStableAmount}
+   */
+  function getStableAmount(
+    uint256 assetAmount,
+    uint256 stableIndex
+  ) public view override returns (uint256 stableAmount) {
+    // Asset is unstaked 1:1 for LP
+    return curveAavePooler.getStableAmount(assetAmount, stableIndex);
+  }
+}

--- a/contracts/src/token/routes/UniV3Pooler.sol
+++ b/contracts/src/token/routes/UniV3Pooler.sol
@@ -1,0 +1,711 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/contracts
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+pragma solidity 0.8.16;
+
+import {SafeMath} from "@openzeppelin/contracts/utils/math/SafeMath.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ERC721Holder} from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
+import {Context} from "@openzeppelin/contracts/utils/Context.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import {SafeMath} from "@openzeppelin/contracts/utils/math/SafeMath.sol";
+
+import {IUniswapV3Pool} from "../../../interfaces/uniswap-v3-core/IUniswapV3Pool.sol";
+import {INonfungiblePositionManager} from "../../../interfaces/uniswap-v3-periphery/INonfungiblePositionManager.sol";
+
+import {IUniV3Pooler} from "../../interfaces/token/routes/IUniV3Pooler.sol";
+import {LiquidityMath} from "../../utils/math/LiquidityMath.sol";
+
+import {CurveAaveStaker} from "./CurveAaveStaker.sol";
+import {UniV3Swapper} from "./UniV3Swapper.sol";
+
+/**
+ * @dev Token router to liquidity to the Uniswap V3 pool in exchange for an
+ * LP NFT
+ */
+contract UniV3Pooler is
+  IUniV3Pooler,
+  Context,
+  ReentrancyGuard,
+  ERC721Holder,
+  LiquidityMath
+{
+  using SafeERC20 for IERC20;
+  using SafeMath for uint256;
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Constants
+  //////////////////////////////////////////////////////////////////////////////
+
+  uint24 public constant FEE_HIGH = 10_000; // 1%
+
+  int24 public constant TICK_LOWER = -887200;
+
+  int24 public constant TICK_UPPER = 887200;
+
+  //////////////////////////////////////////////////////////////////////////////
+  // State
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev The Ultrachess Curve Aave staker contract
+   */
+  CurveAaveStaker public immutable curveAaveStaker;
+
+  /**
+   * @dev The Ultrachess Uniswap V3 swapper
+   */
+  UniV3Swapper public immutable uniV3Swapper;
+
+  /**
+   * @dev The upstream Uniswap V3 pool for the token pair
+   */
+  IUniswapV3Pool public immutable uniswapV3Pool;
+
+  /**
+   * @dev The upstream Uniswap V3 NFT manager
+   */
+  INonfungiblePositionManager public immutable uniswapV3NftManager;
+
+  /**
+   * @dev If true, the base token is token0 and the asset token is token1,
+   * otherwise the reverse
+   */
+  bool public immutable baseIsToken0;
+
+  /**
+   * @dev The Ultrachess base token
+   */
+  IERC20 public immutable baseToken;
+
+  /**
+   * @dev The Ultrachess asset token
+   */
+  IERC20 public immutable assetToken;
+
+  // Public token addresses
+  IERC20 public immutable daiToken;
+  IERC20 public immutable usdcToken;
+  IERC20 public immutable usdtToken;
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Initialization
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Initializes the contract
+   *
+   * @param uniV3Swapper_ The address of our Uniswap V3 swapper contract
+   * @param uniswapV3NftManager_ The address of the Uniswap V3 NFT manager
+   */
+  constructor(address uniV3Swapper_, address uniswapV3NftManager_) {
+    // Validate parameters
+    require(uniV3Swapper_ != address(0), "Invalid swapper");
+    require(uniswapV3NftManager_ != address(0), "Invalid NFT manager");
+
+    // Validate external contracts
+    require(
+      address(UniV3Swapper(uniV3Swapper_).curveAaveStaker()) != address(0),
+      "Invalid univ3 swapper staker"
+    );
+    require(
+      address(UniV3Swapper(uniV3Swapper_).uniswapV3Pool()) != address(0),
+      "Invalid univ3 swapper pool"
+    );
+    require(
+      address(UniV3Swapper(uniV3Swapper_).baseToken()) != address(0),
+      "Invalid univ3 swapper base"
+    );
+    require(
+      address(UniV3Swapper(uniV3Swapper_).assetToken()) != address(0),
+      "Invalid univ3 swapper asset"
+    );
+    require(
+      address(UniV3Swapper(uniV3Swapper_).daiToken()) != address(0),
+      "Invalid univ3 swapper DAI"
+    );
+    require(
+      address(UniV3Swapper(uniV3Swapper_).usdcToken()) != address(0),
+      "Invalid univ3 swapper USDC"
+    );
+    require(
+      address(UniV3Swapper(uniV3Swapper_).usdtToken()) != address(0),
+      "Invalid univ3 swapper USDT"
+    );
+
+    // Initialize state
+    curveAaveStaker = UniV3Swapper(uniV3Swapper_).curveAaveStaker();
+    uniV3Swapper = UniV3Swapper(uniV3Swapper_);
+    uniswapV3Pool = UniV3Swapper(uniV3Swapper_).uniswapV3Pool();
+    uniswapV3NftManager = INonfungiblePositionManager(uniswapV3NftManager_);
+    baseIsToken0 = UniV3Swapper(uniV3Swapper_).baseIsToken0();
+    baseToken = UniV3Swapper(uniV3Swapper_).baseToken();
+    assetToken = IERC20(UniV3Swapper(uniV3Swapper_).assetToken());
+    daiToken = UniV3Swapper(uniV3Swapper_).daiToken();
+    usdcToken = UniV3Swapper(uniV3Swapper_).usdcToken();
+    usdtToken = UniV3Swapper(uniV3Swapper_).usdtToken();
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Implementation of IUniV3Pooler
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev See {IUniV3Pooler-mintNFT}
+   */
+  function mintNFT(
+    uint256[3] memory stableAmounts,
+    uint256 assetSwapAmount,
+    uint256 baseTokenAmount,
+    uint256 baseSwapAmount,
+    address recipient
+  ) public override nonReentrant returns (uint256 nftTokenId) {
+    // Validate parameters
+    require(recipient != address(0), "Invalid recipient");
+
+    // Transfer tokens to this contract
+    _receiveTokens(stableAmounts, baseTokenAmount);
+
+    // Track token balances
+    uint256 baseTokenBalance = baseTokenAmount;
+
+    // Stake any stablecoins into the Curve Aave pool
+    uint256 assetTokenBalance = _stakeStables(stableAmounts);
+
+    // Swap asset tokens into base tokens if desired
+    if (assetSwapAmount > 0) {
+      uint256 baseTokensBought = _buyBaseTokens(assetSwapAmount);
+
+      // Update token balances
+      baseTokenBalance = baseTokenBalance.add(baseTokensBought);
+      assetTokenBalance = assetTokenBalance.sub(assetSwapAmount);
+    }
+
+    // Swap base tokens into asset tokens if desired
+    if (baseSwapAmount > 0) {
+      uint256 assetTokensBought = _sellBaseTokens(baseSwapAmount);
+
+      // Update token balances
+      baseTokenBalance = baseTokenBalance.sub(baseSwapAmount);
+      assetTokenBalance = assetTokenBalance.add(assetTokensBought);
+    }
+
+    // Mint the LP NFT
+    uint256 baseTokenShare;
+    uint256 assetTokenShare;
+    uint256 liquidityAmount;
+    (nftTokenId, baseTokenShare, assetTokenShare, liquidityAmount) = _mintLpNft(
+      baseTokenBalance,
+      assetTokenBalance,
+      recipient
+    );
+
+    // Update token balances
+    baseTokenBalance = baseTokenBalance.sub(baseTokenShare);
+    assetTokenBalance = assetTokenBalance.sub(assetTokenShare);
+
+    // Swap any remaining asset tokens for base tokens
+    // slither-disable-next-line timestamp
+    if (assetTokenBalance > 0) {
+      uint256 baseTokensBought = _buyBaseTokens(assetTokenBalance);
+
+      // Update token balance
+      baseTokenBalance = baseTokenBalance.add(baseTokensBought);
+    }
+
+    // Return base tokens to the recipient
+    _returnBaseTokens(recipient, baseTokenBalance);
+
+    // Dispatch event
+    // slither-disable-next-line reentrancy-events
+    emit NFTMinted(
+      _msgSender(),
+      recipient,
+      address(uniswapV3NftManager),
+      nftTokenId,
+      stableAmounts,
+      baseTokenAmount,
+      baseTokenShare,
+      assetTokenShare,
+      liquidityAmount
+    );
+
+    return nftTokenId;
+  }
+
+  /**
+   * @dev See {IUniV3Pooler-mintNFTWithStables}
+   */
+  function mintNFTWithStables(
+    uint256[3] memory stableAmounts,
+    address recipient
+  ) public override returns (uint256 nftTokenId) {
+    // Validate parameters
+    require(recipient != address(0), "Invalid recipient");
+
+    // Get the asset amount for the given amount of stablecoins
+    uint256 assetAmount = curveAaveStaker.getAssetAmount(stableAmounts, true);
+
+    // Calculate asset token reserve
+    uint256 assetTokenReserve = assetToken.balanceOf(address(uniswapV3Pool));
+
+    // Get the pool fee
+    uint24 poolFee = uniswapV3Pool.fee();
+
+    // Calculate asset swap amount
+    uint256 assetSwapAmount = computeSwapAmountV2(
+      assetTokenReserve,
+      assetAmount,
+      poolFee
+    );
+
+    // Mint the NFT
+    nftTokenId = mintNFT(stableAmounts, assetSwapAmount, 0, 0, recipient);
+
+    return nftTokenId;
+  }
+
+  /**
+   * @dev See {IUniV3Pooler-mintNFTWithBaseToken}
+   */
+  function mintNFTWithBaseToken(
+    uint256 baseTokenAmount,
+    address recipient
+  ) public override returns (uint256 nftTokenId) {
+    // Validate parameters
+    require(recipient != address(0), "Invalid recipient");
+
+    // Calculate base token reserve
+    uint256 baseTokenReserve = baseToken.balanceOf(address(uniswapV3Pool));
+
+    // Get the pool fee
+    uint24 poolFee = uniswapV3Pool.fee();
+
+    // Calculate base swap amount
+    uint256 baseSwapAmount = LiquidityMath.computeSwapAmountV2(
+      baseTokenReserve,
+      baseTokenAmount,
+      poolFee
+    );
+
+    // Mint the NFT
+    nftTokenId = mintNFT(
+      [uint256(0), uint256(0), uint256(0)],
+      0,
+      baseTokenAmount,
+      baseSwapAmount,
+      recipient
+    );
+
+    return nftTokenId;
+  }
+
+  /**
+   * @dev See {IUniV3Pooler-mintNFTOneStable}
+   */
+  function mintNFTOneStable(
+    uint256 stableIndex,
+    uint256 stableAmount
+  ) public override returns (uint256 nftTokenId) {
+    // Validate parameters
+    require(stableIndex <= 2, "Invalid stable");
+    require(stableAmount > 0, "Invalid amount");
+
+    // Create stablecoin amounts array
+    uint256[3] memory stableAmounts;
+    stableAmounts[stableIndex] = stableAmount;
+
+    // Mint the NFT
+    nftTokenId = mintNFTWithStables(stableAmounts, _msgSender());
+
+    return nftTokenId;
+  }
+
+  /**
+   * @dev See {IUniV3Pooler-mintNFT}
+   */
+  function mintNFTImbalance(
+    uint256[3] memory stableAmounts,
+    uint256 baseTokenAmount,
+    address recipient
+  ) public override returns (uint256 nftTokenId) {
+    // Validate parameters
+    require(recipient != address(0), "Invalid recipient");
+
+    // Mint the NFT
+    nftTokenId = mintNFT(stableAmounts, 0, baseTokenAmount, 0, recipient);
+
+    return nftTokenId;
+  }
+
+  /**
+   * @dev See {IUniV3Pooler-collectFromNFT}
+   */
+  function collectFromNFT(
+    uint256 nftTokenId,
+    uint256 stableIndex,
+    address recipient
+  ) public override nonReentrant returns (uint256 stablesReturned) {
+    // Validate parameters
+    require(stableIndex <= 2, "Invalid stable");
+    require(recipient != address(0), "Invalid recipient");
+
+    // Read state
+    (, , , , , , , uint128 uniV3LiquidityAmount, , , , ) = uniswapV3NftManager
+      .positions(nftTokenId);
+
+    // Translate parameters
+    uint256 liquidityAmount = SafeCast.toUint256(
+      SafeCast.toInt256(uniV3LiquidityAmount)
+    );
+
+    // Collect tokens and fees from LP NFT
+    (uint256 baseTokensCollected, uint256 assetTokensCollected) = _collectLpNft(
+      nftTokenId,
+      uniV3LiquidityAmount
+    );
+
+    // Track token balance
+    uint256 assetTokenBalance = assetTokensCollected;
+
+    // Swap the base token for the asset token
+    if (baseTokensCollected > 0) {
+      uint256 assetTokensBought = _sellBaseTokens(baseTokensCollected);
+
+      // Update token balance
+      assetTokenBalance = assetTokenBalance.add(assetTokensBought);
+    }
+
+    // Unstake stablecoins
+    if (assetTokenBalance > 0) {
+      stablesReturned = _unstakeOneStable(assetTokenBalance, stableIndex);
+    }
+
+    // Return tokens from this contract
+    _returnStables(recipient, stableIndex, stablesReturned);
+
+    // Return the LP NFT to the recipient
+    uniswapV3NftManager.safeTransferFrom(address(this), recipient, nftTokenId);
+
+    // Dispatch event
+    // slither-disable-next-line reentrancy-events
+    emit NFTCollected(
+      _msgSender(),
+      recipient,
+      address(uniswapV3NftManager),
+      nftTokenId,
+      liquidityAmount,
+      baseTokensCollected,
+      assetTokensCollected,
+      stableIndex,
+      stablesReturned
+    );
+
+    return stablesReturned;
+  }
+
+  /**
+   * @dev See {IUniV3Pooler-exitOneStable}
+   */
+  function exitOneStable(
+    uint256 nftTokenId,
+    uint256 stableIndex
+  ) public override returns (uint256 stablesReturned) {
+    // Validate parameters
+    require(stableIndex <= 2, "Invalid stable");
+
+    // Collect and transfer the NFT back to the sender
+    stablesReturned = collectFromNFT(nftTokenId, stableIndex, _msgSender());
+
+    return stablesReturned;
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Private functions
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Transfer tokens to this contract and approve the Curve Aave staker to
+   * spend stablecoins
+   *
+   * @param stableAmounts The amounts of stablecoins to transfer
+   * @param baseTokenAmount The amount of base tokens to transfer
+   */
+  function _receiveTokens(
+    uint256[3] memory stableAmounts,
+    uint256 baseTokenAmount
+  ) private {
+    // Call external contracts
+    if (stableAmounts[0] > 0) {
+      daiToken.safeTransferFrom(_msgSender(), address(this), stableAmounts[0]);
+      daiToken.safeIncreaseAllowance(
+        address(curveAaveStaker),
+        stableAmounts[0]
+      );
+    }
+    if (stableAmounts[1] > 0) {
+      usdcToken.safeTransferFrom(_msgSender(), address(this), stableAmounts[1]);
+      usdcToken.safeIncreaseAllowance(
+        address(curveAaveStaker),
+        stableAmounts[1]
+      );
+    }
+    if (stableAmounts[2] > 0) {
+      usdtToken.safeTransferFrom(_msgSender(), address(this), stableAmounts[2]);
+      usdtToken.safeIncreaseAllowance(
+        address(curveAaveStaker),
+        stableAmounts[2]
+      );
+    }
+    if (baseTokenAmount > 0) {
+      baseToken.safeTransferFrom(_msgSender(), address(this), baseTokenAmount);
+    }
+  }
+
+  /**
+   * @dev Return stablecoins to the recipient
+   *
+   * @param recipient The recipient of the tokens
+   * @param stableIndex The index of the stablecoin to return
+   * @param stableAmount The amount of stablecoins to return
+   */
+  function _returnStables(
+    address recipient,
+    uint256 stableIndex,
+    uint256 stableAmount
+  ) private {
+    // Call external contracts
+    if (stableIndex == 0) {
+      daiToken.safeTransfer(recipient, stableAmount);
+    } else if (stableIndex == 1) {
+      usdcToken.safeTransfer(recipient, stableAmount);
+    } else if (stableIndex == 2) {
+      usdtToken.safeTransfer(recipient, stableAmount);
+    }
+  }
+
+  /**
+   * @dev Return base tokens to the recipient
+   *
+   * @param recipient The recipient of the tokens
+   * @param baseTokenAmount The amount of base tokens to return
+   */
+  function _returnBaseTokens(
+    address recipient,
+    uint256 baseTokenAmount
+  ) private {
+    // Call external contracts
+    // slither-disable-next-line timestamp
+    if (baseTokenAmount > 0) {
+      baseToken.safeTransfer(recipient, baseTokenAmount);
+    }
+  }
+
+  /**
+   * @dev Stake any stablecoins in the Curve Aave staker
+   *
+   * @param stableAmounts The amounts of stablecoins to stake
+   *
+   * @return assetTokenAmount The amount of asset tokens received
+   */
+  function _stakeStables(
+    uint256[3] memory stableAmounts
+  ) private returns (uint256 assetTokenAmount) {
+    if (stableAmounts[0] > 0 || stableAmounts[1] > 0 || stableAmounts[2] > 0) {
+      assetTokenAmount = curveAaveStaker.stakeTokens(
+        stableAmounts,
+        address(this)
+      );
+    }
+
+    return assetTokenAmount;
+  }
+
+  /**
+   * @dev Unstake stablecoins from the Curve Aave staker
+   *
+   * @param assetTokenAmount The amount of asset tokens to unstake
+   * @param stableIndex The index of the stablecoin to receive
+   *
+   * @return stablesReturned The amount of stablecoins received
+   */
+  function _unstakeOneStable(
+    uint256 assetTokenAmount,
+    uint256 stableIndex
+  ) private returns (uint256 stablesReturned) {
+    // Approve the Curve Aave staker to spend asset tokens
+    assetToken.safeIncreaseAllowance(
+      address(curveAaveStaker),
+      assetTokenAmount
+    );
+
+    // Unstake the asset token for stables
+    stablesReturned = curveAaveStaker.unstakeOneStable(
+      assetTokenAmount,
+      stableIndex,
+      address(this)
+    );
+
+    return stablesReturned;
+  }
+
+  /**
+   * @dev Buy base tokens with asset tokens
+   *
+   * @param assetSwapAmount The amount of asset tokens to swap into base tokens
+   *
+   * @return baseTokensBought The amount of base tokens bought
+   */
+  function _buyBaseTokens(
+    uint256 assetSwapAmount
+  ) private returns (uint256 baseTokensBought) {
+    // Approve the swapper to spend asset tokens
+    assetToken.safeIncreaseAllowance(address(uniV3Swapper), assetSwapAmount);
+
+    // Buy base tokens
+    baseTokensBought = uniV3Swapper.buyTokens(
+      [uint256(0), uint256(0), uint256(0)],
+      assetSwapAmount,
+      address(this)
+    );
+
+    return baseTokensBought;
+  }
+
+  /**
+   * @dev Buy asset tokens with base tokens
+   *
+   * @param baseSwapAmount The amount of base tokens to swap into asset tokens
+   *
+   * @return assetTokensBought The amount of asset tokens bought
+   */
+  function _sellBaseTokens(
+    uint256 baseSwapAmount
+  ) private returns (uint256 assetTokensBought) {
+    // Approve the swapper to spend base tokens
+    baseToken.safeIncreaseAllowance(address(uniV3Swapper), baseSwapAmount);
+
+    // Buy asset tokens
+    assetTokensBought = uniV3Swapper.sellTokensForAsset(
+      baseSwapAmount,
+      address(this)
+    );
+
+    return assetTokensBought;
+  }
+
+  /**
+   * @dev Mint an LP NFT
+   *
+   * @param baseTokenAmount The amount of base tokens to add to the pool
+   * @param assetTokenAmount The amount of asset tokens to add to the pool
+   * @param recipient The recipient of the LP NFT
+   *
+   * @return nftTokenId The ID of the LP NFT
+   * @return baseTokenShare The amount of base tokens in the LP NFT
+   * @return assetTokenShare The amount of asset tokens in the LP NFT
+   * @return liquidityAmount The amount of liquidity in the LP NFT
+   */
+  function _mintLpNft(
+    uint256 baseTokenAmount,
+    uint256 assetTokenAmount,
+    address recipient
+  )
+    private
+    returns (
+      uint256 nftTokenId,
+      uint256 baseTokenShare,
+      uint256 assetTokenShare,
+      uint256 liquidityAmount
+    )
+  {
+    // Approve the NFT manager to spend the base and asset tokens
+    baseToken.safeIncreaseAllowance(
+      address(uniswapV3NftManager),
+      baseTokenAmount
+    );
+    assetToken.safeIncreaseAllowance(
+      address(uniswapV3NftManager),
+      assetTokenAmount
+    );
+
+    // Mint the LP NFT
+    uint256 amount0;
+    uint256 amount1;
+    (nftTokenId, liquidityAmount, amount0, amount1) = uniswapV3NftManager.mint(
+      INonfungiblePositionManager.MintParams({
+        token0: baseIsToken0 ? address(baseToken) : address(assetToken),
+        token1: baseIsToken0 ? address(assetToken) : address(baseToken),
+        fee: FEE_HIGH,
+        tickLower: TICK_LOWER,
+        tickUpper: TICK_UPPER,
+        amount0Desired: baseIsToken0 ? baseTokenAmount : assetTokenAmount,
+        amount1Desired: baseIsToken0 ? assetTokenAmount : baseTokenAmount,
+        amount0Min: 0,
+        amount1Min: 0,
+        recipient: recipient,
+        // slither-disable-next-line timestamp
+        deadline: block.timestamp
+      })
+    );
+
+    // Calculate results
+    baseTokenShare = baseIsToken0 ? amount0 : amount1;
+    assetTokenShare = baseIsToken0 ? amount1 : amount0;
+
+    return (nftTokenId, baseTokenShare, assetTokenShare, liquidityAmount);
+  }
+
+  /**
+   * @dev Collect tokens and fees from an LP NFT
+   *
+   * @param nftTokenId The ID of the LP NFT
+   * @param liquidityAmount The amount of liquidity to collect
+   *
+   * @return baseTokensCollected The amount of base tokens collected
+   * @return assetTokensCollected The amount of asset tokens collected
+   */
+  function _collectLpNft(
+    uint256 nftTokenId,
+    uint128 liquidityAmount
+  )
+    private
+    returns (uint256 baseTokensCollected, uint256 assetTokensCollected)
+  {
+    // Withdraw tokens from the pool
+    // slither-disable-next-line unused-return
+    uniswapV3NftManager.decreaseLiquidity(
+      INonfungiblePositionManager.DecreaseLiquidityParams({
+        tokenId: nftTokenId,
+        liquidity: liquidityAmount,
+        amount0Min: 0,
+        amount1Min: 0,
+        // slither-disable-next-line timestamp
+        deadline: block.timestamp
+      })
+    );
+
+    // Collect the tokens and fees
+    (uint256 amount0, uint256 amount1) = uniswapV3NftManager.collect(
+      INonfungiblePositionManager.CollectParams({
+        tokenId: nftTokenId,
+        recipient: address(this),
+        amount0Max: type(uint128).max,
+        amount1Max: type(uint128).max
+      })
+    );
+
+    // Calculate results
+    baseTokensCollected = baseIsToken0 ? amount0 : amount1;
+    assetTokensCollected = baseIsToken0 ? amount1 : amount0;
+
+    return (baseTokensCollected, assetTokensCollected);
+  }
+}

--- a/contracts/src/token/routes/UniV3Staker.sol
+++ b/contracts/src/token/routes/UniV3Staker.sol
@@ -1,0 +1,636 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/contracts
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+pragma solidity 0.8.16;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {SafeMath} from "@openzeppelin/contracts/utils/math/SafeMath.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ERC721Holder} from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
+import {Context} from "@openzeppelin/contracts/utils/Context.sol";
+import {SafeMath} from "@openzeppelin/contracts/utils/math/SafeMath.sol";
+
+import {IERC20Minimal} from "../../../interfaces/uniswap-v3-core/IERC20Minimal.sol";
+import {IUniswapV3Pool} from "../../../interfaces/uniswap-v3-core/IUniswapV3Pool.sol";
+import {INonfungiblePositionManager} from "../../../interfaces/uniswap-v3-periphery/INonfungiblePositionManager.sol";
+import {IUniswapV3Staker} from "../../../interfaces/uniswap-v3-staker/IUniswapV3Staker.sol";
+
+import {IUniV3Staker} from "../../interfaces/token/routes/IUniV3Staker.sol";
+
+import {LpSft} from "../LpSft.sol";
+
+import {UniV3Pooler} from "./UniV3Pooler.sol";
+
+/**
+ * @dev Token router to liquidity to the Uniswap V3 pool in exchange for an
+ * LP NFT
+ */
+contract UniV3Staker is
+  IUniV3Staker,
+  Context,
+  Ownable,
+  ReentrancyGuard,
+  ERC721Holder
+{
+  using SafeERC20 for IERC20;
+  using SafeMath for uint256;
+
+  //////////////////////////////////////////////////////////////////////////////
+  // State
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev The Ultrachess Uniswap V3 pooler
+   */
+  UniV3Pooler public immutable uniV3Pooler;
+
+  /**
+   * @dev The upstream Uniswap V3 pool for the token pair
+   */
+  IUniswapV3Pool public immutable uniswapV3Pool;
+
+  /**
+   * @dev The upstream Uniswap V3 NFT manager
+   */
+  INonfungiblePositionManager public immutable uniswapV3NftManager;
+
+  /**
+   * @dev The upstream Uniswap V3 NFT staker
+   */
+  IUniswapV3Staker public immutable uniswapV3Staker;
+
+  /**
+   * @dev The Ultrachess LP SFT contract
+   */
+  LpSft public immutable lpSft;
+
+  /**
+   * @dev If true, the base token is token0 and the asset token is token1,
+   * otherwise the reverse
+   */
+  bool public immutable baseIsToken0;
+
+  /**
+   * @dev The Ultrachess base token
+   */
+  IERC20 public immutable baseToken;
+
+  /**
+   * @dev The Ultrachess asset token
+   */
+  IERC20 public immutable assetToken;
+
+  // Public token addresses
+  IERC20 public immutable daiToken;
+  IERC20 public immutable usdcToken;
+  IERC20 public immutable usdtToken;
+
+  /**
+   * @dev True if the incentive has been created, false otherwise
+   */
+  bool public incentiveCreated = false;
+
+  /**
+   * @dev The Uniswap V3 staker incentive key, calculated when the incentive is
+   * created
+   */
+  IUniswapV3Staker.IncentiveKey public incentiveKey;
+
+  /**
+   * @dev The Uniswap V3 staker incentive ID, calculated when the incentive is
+   * created
+   */
+  bytes32 public incentiveId;
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Initialization
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Initializes the contract
+   *
+   * @param owner_ The initial owner of the contract
+   * @param uniV3Pooler_ The address of our Uniswap V3 pooler contract
+   * @param uniswapV3Staker_ The address of the Uniswap V3 staker contract
+   * @param lpSft_ The address of the LP SFT contract
+   */
+  constructor(
+    address owner_,
+    address uniV3Pooler_,
+    address uniswapV3Staker_,
+    address lpSft_
+  ) {
+    // Validate parameters
+    require(uniV3Pooler_ != address(0), "Invalid swapper");
+    require(uniswapV3Staker_ != address(0), "Invalid staker");
+    require(lpSft_ != address(0), "Invalid LP SFT");
+
+    // Validate external contracts
+    require(
+      address(UniV3Pooler(uniV3Pooler_).uniswapV3Pool()) != address(0),
+      "Invalid univ3 pooler pool"
+    );
+    require(
+      address(UniV3Pooler(uniV3Pooler_).uniswapV3NftManager()) != address(0),
+      "Invalid univ3 pooler mgr"
+    );
+    require(
+      address(UniV3Pooler(uniV3Pooler_).baseToken()) != address(0),
+      "Invalid univ3 pooler base"
+    );
+    require(
+      address(UniV3Pooler(uniV3Pooler_).assetToken()) != address(0),
+      "Invalid univ3 pooler asset"
+    );
+    require(
+      address(UniV3Pooler(uniV3Pooler_).daiToken()) != address(0),
+      "Invalid univ3 pooler DAI"
+    );
+    require(
+      address(UniV3Pooler(uniV3Pooler_).usdcToken()) != address(0),
+      "Invalid univ3 pooler USDC"
+    );
+    require(
+      address(UniV3Pooler(uniV3Pooler_).usdtToken()) != address(0),
+      "Invalid univ3 pooler USDT"
+    );
+
+    // Initialize {Ownable}
+    transferOwnership(owner_);
+
+    // Initialize state
+    uniV3Pooler = UniV3Pooler(uniV3Pooler_);
+    uniswapV3Pool = UniV3Pooler(uniV3Pooler_).uniswapV3Pool();
+    uniswapV3NftManager = UniV3Pooler(uniV3Pooler_).uniswapV3NftManager();
+    uniswapV3Staker = IUniswapV3Staker(uniswapV3Staker_);
+    lpSft = LpSft(lpSft_);
+    baseIsToken0 = UniV3Pooler(uniV3Pooler_).baseIsToken0();
+    baseToken = UniV3Pooler(uniV3Pooler_).baseToken();
+    assetToken = UniV3Pooler(uniV3Pooler_).assetToken();
+    daiToken = UniV3Pooler(uniV3Pooler_).daiToken();
+    usdcToken = UniV3Pooler(uniV3Pooler_).usdcToken();
+    usdtToken = UniV3Pooler(uniV3Pooler_).usdtToken();
+  }
+
+  /**
+   * @dev Initializes the staker incentive
+   *
+   * @param reward The reward to distribute in the incentive
+   *
+   * TODO: Allow creating multiple incentives?
+   */
+  function createIncentive(uint256 reward) public onlyOwner {
+    // Validate state
+    require(!incentiveCreated, "Incentive already created");
+
+    // Update state
+    incentiveCreated = true;
+    incentiveKey = _createIncentiveKey();
+
+    // See IncentiveId.sol in the Uniswap V3 staker dependency
+    incentiveId = keccak256(abi.encode(incentiveKey));
+
+    // Transfer the reward to this contract
+    baseToken.safeTransferFrom(_msgSender(), address(this), reward);
+
+    // Approve the Uniswap V3 staker to spend the reward
+    baseToken.safeIncreaseAllowance(address(uniswapV3Staker), reward);
+
+    // Create the incentive
+    uniswapV3Staker.createIncentive(incentiveKey, reward);
+
+    // Dispatch event
+    // slither-disable-next-line reentrancy-events
+    emit IncentiveCreated(
+      _msgSender(),
+      reward,
+      incentiveKey.startTime,
+      incentiveKey.endTime,
+      incentiveKey.refundee
+    );
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Implementation of {IUniV3Staker}
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev See {IUniV3Staker-stakeNFTWithStables}
+   */
+  function stakeNFTWithStables(
+    uint256[3] memory stableAmounts,
+    address recipient
+  ) public override nonReentrant returns (uint256 nftTokenId) {
+    // Validate parameters
+    require(recipient != address(0), "Invalid recipient");
+
+    // Receive tokens from the caller
+    _receiveTokens(stableAmounts, 0);
+
+    // Mint the LP NFT
+    nftTokenId = uniV3Pooler.mintNFTWithStables(stableAmounts, address(this));
+
+    // Return the LP SFT and the base token dust
+    _returnSftAndDust(nftTokenId, recipient);
+
+    // Dispatch event
+    // slither-disable-next-line reentrancy-events
+    emit NFTStaked(
+      _msgSender(),
+      recipient,
+      address(uniswapV3NftManager),
+      nftTokenId,
+      stableAmounts,
+      0
+    );
+
+    return nftTokenId;
+  }
+
+  /**
+   * @dev See {IUniV3Staker-stakeNFTOneStable}
+   */
+  function stakeNFTOneStable(
+    uint256 stableIndex,
+    uint256 stableAmount
+  ) public override returns (uint256 nftTokenId) {
+    // Validate parameters
+    require(stableIndex <= 2, "Invalid stable");
+    require(stableAmount > 0, "Invalid amount");
+
+    // Create stablecoin amounts array
+    uint256[3] memory stableAmounts;
+    stableAmounts[stableIndex] = stableAmount;
+
+    // Mint and stake the NFT
+    nftTokenId = stakeNFTWithStables(stableAmounts, _msgSender());
+
+    return nftTokenId;
+  }
+
+  /**
+   * @dev See {IUniV3Staker-stakeNFTWithBaseToken}
+   */
+  function stakeNFTWithBaseToken(
+    uint256 baseTokenAmount,
+    address recipient
+  ) public override nonReentrant returns (uint256 nftTokenId) {
+    // Validate parameters
+    require(recipient != address(0), "Invalid recipient");
+
+    // Receive tokens from the caller
+    _receiveTokens([uint256(0), uint256(0), uint256(0)], baseTokenAmount);
+
+    // Mint the LP NFT
+    nftTokenId = uniV3Pooler.mintNFTWithBaseToken(
+      baseTokenAmount,
+      address(this)
+    );
+
+    // Return the LP SFT and the base token dust
+    _returnSftAndDust(nftTokenId, recipient);
+
+    // Dispatch event
+    // slither-disable-next-line reentrancy-events
+    emit NFTStaked(
+      _msgSender(),
+      recipient,
+      address(uniswapV3NftManager),
+      nftTokenId,
+      [uint256(0), uint256(0), uint256(0)],
+      baseTokenAmount
+    );
+
+    return nftTokenId;
+  }
+
+  /**
+   * @dev See {IUniV3Staker-stakeNFTImbalance}
+   */
+  function stakeNFTImbalance(
+    uint256[3] memory stableAmounts,
+    uint256 baseTokenAmount,
+    address recipient
+  ) public override nonReentrant returns (uint256 nftTokenId) {
+    // Validate parameters
+    require(recipient != address(0), "Invalid recipient");
+
+    // Receive tokens from the caller
+    _receiveTokens(stableAmounts, baseTokenAmount);
+
+    // Mint the LP NFT
+    nftTokenId = uniV3Pooler.mintNFTImbalance(
+      stableAmounts,
+      baseTokenAmount,
+      address(this)
+    );
+
+    // Return the LP SFT and the base token dust
+    _returnSftAndDust(nftTokenId, recipient);
+
+    // Dispatch event
+    // slither-disable-next-line reentrancy-events
+    emit NFTStaked(
+      _msgSender(),
+      recipient,
+      address(uniswapV3NftManager),
+      nftTokenId,
+      stableAmounts,
+      baseTokenAmount
+    );
+
+    return nftTokenId;
+  }
+
+  /**
+   * @dev See {IUniV3Staker-unstakeNFT}
+   */
+  function unstakeNFT(
+    uint256 nftTokenId,
+    uint256 stableIndex,
+    address recipient
+  ) public override nonReentrant returns (uint256 stablesReturned) {
+    // Validate parameters
+    require(stableIndex <= 2, "Invalid stable");
+    require(recipient != address(0), "Invalid recipient");
+
+    // Validate ownership
+    require(lpSft.balanceOf(_msgSender(), nftTokenId) == 1, "Must own voucher");
+
+    // Burn the voucher for the LP NFT
+    lpSft.burn(_msgSender(), nftTokenId);
+
+    // Read state
+    uint256 rewardBefore = uniswapV3Staker.rewards(
+      incentiveKey.rewardToken,
+      address(this)
+    );
+
+    // Unstake the LP NFT
+    uniswapV3Staker.unstakeToken(incentiveKey, nftTokenId);
+
+    // Read state
+    uint256 rewardAfter = uniswapV3Staker.rewards(
+      incentiveKey.rewardToken,
+      address(this)
+    );
+
+    // Claim the reward
+    uint256 rewardClaimed = uniswapV3Staker.claimReward(
+      incentiveKey.rewardToken,
+      address(this),
+      rewardAfter.sub(rewardBefore)
+    );
+
+    // Withdraw the LP NFT to the pooler so that it can collect the liquidity
+    uniswapV3Staker.withdrawToken(nftTokenId, address(uniV3Pooler), "");
+
+    // Withdraw the liquidity. This returns the LP NFT to the staker.
+    stablesReturned = uniV3Pooler.collectFromNFT(
+      nftTokenId,
+      stableIndex,
+      address(this)
+    );
+
+    // Transfer the empty LP NFT to the recipient as a keepsake
+    uniswapV3NftManager.safeTransferFrom(address(this), recipient, nftTokenId);
+
+    // Return stablecoins to the recipient
+    _returnStables(recipient, stableIndex, stablesReturned);
+
+    // Dispatch event
+    // slither-disable-next-line reentrancy-events
+    emit NFTUnstaked(
+      _msgSender(),
+      recipient,
+      address(uniswapV3NftManager),
+      nftTokenId,
+      rewardClaimed,
+      stableIndex,
+      stablesReturned
+    );
+
+    return stablesReturned;
+  }
+
+  /**
+   * @dev See {IUniV3Staker-exitOneStable}
+   */
+  function exitOneStable(
+    uint256 nftTokenId,
+    uint256 stableIndex
+  ) public override returns (uint256 stablesReturned) {
+    // Validate parameters
+    require(stableIndex <= 2, "Invalid stable");
+
+    // Unstake and transfer the LP NFT
+    stablesReturned = unstakeNFT(nftTokenId, stableIndex, _msgSender());
+
+    return stablesReturned;
+  }
+
+  /**
+   * @dev See {IUniV3Staker-getIncentive}
+   */
+  function getIncentive()
+    public
+    view
+    override
+    returns (
+      uint256 totalRewardUnclaimed,
+      uint160 totalSecondsClaimedX128,
+      uint96 numberOfStakes
+    )
+  {
+    // Validate state
+    require(incentiveCreated, "Incentive not created");
+
+    // Call external contract
+    return uniswapV3Staker.incentives(incentiveId);
+  }
+
+  /**
+   * @dev See {IUniV3Staker-getDeposit}
+   */
+  function getDeposit(
+    uint256 tokenId
+  )
+    public
+    view
+    override
+    returns (
+      address owner_,
+      uint48 numberOfStakes,
+      int24 tickLower,
+      int24 tickUpper
+    )
+  {
+    // Call external contract
+    (owner_, numberOfStakes, tickLower, tickUpper) = uniswapV3Staker.deposits(
+      tokenId
+    );
+
+    // Validate result
+    require(owner_ == address(this), "Invalid owner");
+
+    // Translate result
+    owner_ = lpSft.ownerOf(tokenId);
+
+    return (owner_, numberOfStakes, tickLower, tickUpper);
+  }
+
+  /**
+   * @dev See {IUniV3Staker-getStake}
+   */
+  function getStake(
+    uint256 tokenId
+  )
+    public
+    view
+    override
+    returns (uint160 secondsPerLiquidityInsideInitialX128, uint128 liquidity)
+  {
+    // Validate state
+    require(incentiveCreated, "Incentive not created");
+
+    // Call external contract
+    return uniswapV3Staker.stakes(tokenId, incentiveId);
+  }
+
+  /**
+   * @dev See {IUniV3Staker-getRewardsOwed}
+   */
+  function getRewardsOwed(
+    address owner_
+  ) public view override returns (uint256 rewardsOwed) {
+    // Validate state
+    require(incentiveCreated, "Incentive not created");
+
+    // Call external contract
+    return uniswapV3Staker.rewards(incentiveKey.rewardToken, owner_);
+  }
+
+  /**
+   * @dev See {IUniV3Staker-getRewardInfo}
+   */
+  function getRewardInfo(
+    uint256 tokenId
+  ) public override returns (uint256 reward, uint160 secondsInsideX128) {
+    // Validate state
+    require(incentiveCreated, "Incentive not created");
+
+    // Call external contract
+    return uniswapV3Staker.getRewardInfo(incentiveKey, tokenId);
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Private functions
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Transfer tokens to this contract and approve the UniV3 Pooler to
+   * spend tokens
+   *
+   * @param stableAmounts The amounts of stablecoins to transfer
+   * @param baseTokenAmount The amount of base tokens to transfer
+   */
+  function _receiveTokens(
+    uint256[3] memory stableAmounts,
+    uint256 baseTokenAmount
+  ) private {
+    // Call external contracts
+    if (stableAmounts[0] > 0) {
+      daiToken.safeTransferFrom(_msgSender(), address(this), stableAmounts[0]);
+      daiToken.safeIncreaseAllowance(address(uniV3Pooler), stableAmounts[0]);
+    }
+    if (stableAmounts[1] > 0) {
+      usdcToken.safeTransferFrom(_msgSender(), address(this), stableAmounts[1]);
+      usdcToken.safeIncreaseAllowance(address(uniV3Pooler), stableAmounts[1]);
+    }
+    if (stableAmounts[2] > 0) {
+      usdtToken.safeTransferFrom(_msgSender(), address(this), stableAmounts[2]);
+      usdtToken.safeIncreaseAllowance(address(uniV3Pooler), stableAmounts[2]);
+    }
+    if (baseTokenAmount > 0) {
+      baseToken.safeTransferFrom(_msgSender(), address(this), baseTokenAmount);
+      baseToken.safeIncreaseAllowance(address(uniV3Pooler), baseTokenAmount);
+    }
+  }
+
+  /**
+   * @dev Return stablecoins to the recipient
+   *
+   * @param recipient The recipient of the tokens
+   * @param stableIndex The index of the stablecoin to return
+   * @param stableAmount The amount of stablecoins to return
+   */
+  function _returnStables(
+    address recipient,
+    uint256 stableIndex,
+    uint256 stableAmount
+  ) private {
+    // Call external contracts
+    if (stableIndex == 0) {
+      daiToken.safeTransfer(recipient, stableAmount);
+    } else if (stableIndex == 1) {
+      usdcToken.safeTransfer(recipient, stableAmount);
+    } else if (stableIndex == 2) {
+      usdtToken.safeTransfer(recipient, stableAmount);
+    }
+  }
+
+  /**
+   * @dev Mint an LP SFT and return it, along with the dust, to the recipient
+   *
+   * @param nftTokenId The ID of the LP NFT
+   * @param recipient The recipient of the LP SFT and dust
+   */
+  function _returnSftAndDust(uint256 nftTokenId, address recipient) private {
+    // Mint the recipient a voucher for the LP NFT. This must be held by the
+    // sender when unstaking the NFT.
+    // slither-disable-next-line reentrancy-events
+    lpSft.mint(recipient, nftTokenId);
+
+    // Send the LP NFT to the Uniswap V3 staker contract and automatically
+    // stake it
+    uniswapV3NftManager.safeTransferFrom(
+      address(this),
+      address(uniswapV3Staker),
+      nftTokenId,
+      abi.encode(incentiveKey)
+    );
+
+    // Return dust to the recipient
+    uint256 baseTokenDust = baseToken.balanceOf(address(this));
+    if (baseTokenDust > 0) {
+      baseToken.safeTransfer(recipient, baseTokenDust);
+    }
+  }
+
+  /**
+   * @dev Returns the incentive key for the Uniswap V3 staker
+   */
+  function _createIncentiveKey()
+    private
+    view
+    returns (IUniswapV3Staker.IncentiveKey memory)
+  {
+    return
+      IUniswapV3Staker.IncentiveKey({
+        rewardToken: IERC20Minimal(address(baseToken)),
+        pool: uniswapV3Pool,
+        // slither-disable-next-line timestamp
+        startTime: block.timestamp,
+        // slither-disable-next-line timestamp
+        endTime: block.timestamp + 1 weeks, // TODO
+        refundee: address(this)
+      });
+  }
+}

--- a/contracts/src/token/routes/UniV3Swapper.sol
+++ b/contracts/src/token/routes/UniV3Swapper.sol
@@ -1,0 +1,556 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/contracts
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+pragma solidity 0.8.16;
+
+import {SafeMath} from "@openzeppelin/contracts/utils/math/SafeMath.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Context} from "@openzeppelin/contracts/utils/Context.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import {SafeMath} from "@openzeppelin/contracts/utils/math/SafeMath.sol";
+
+import {IUniswapV3SwapCallback} from "../../../interfaces/uniswap-v3-core/callback/IUniswapV3SwapCallback.sol";
+import {IUniswapV3Pool} from "../../../interfaces/uniswap-v3-core/IUniswapV3Pool.sol";
+
+import {IUniV3Swapper} from "../../interfaces/token/routes/IUniV3Swapper.sol";
+
+import {CurveAaveStaker} from "./CurveAaveStaker.sol";
+
+/**
+ * @dev Token router to swap between the base token and one of serveral
+ * underlying stablecoins that the protocol is built on
+ */
+contract UniV3Swapper is
+  IUniV3Swapper,
+  IUniswapV3SwapCallback,
+  Context,
+  ReentrancyGuard
+{
+  using SafeERC20 for IERC20;
+  using SafeMath for uint256;
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Constants
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev The minimum value that can be returned from {TickMath-getSqrtRatioAtTick}
+   *
+   * Equivalent to getSqrtRatioAtTick(MIN_TICK).
+   */
+  uint160 internal constant MIN_SQRT_RATIO = 4295128739;
+
+  /**
+   * @dev The maximum value that can be returned from {TickMath-getSqrtRatioAtTick}
+   *
+   * Equivalent to getSqrtRatioAtTick(MAX_TICK).
+   */
+  uint160 internal constant MAX_SQRT_RATIO =
+    1461446703485210103287273052203988822378723970342;
+
+  //////////////////////////////////////////////////////////////////////////////
+  // State
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev The Curve Aave staker contract
+   */
+  CurveAaveStaker public immutable curveAaveStaker;
+
+  /**
+   * @dev The Uniswap V3 pool for the token pair
+   */
+  IUniswapV3Pool public immutable uniswapV3Pool;
+
+  /**
+   * @dev True if the base token is sorted first in the Uniswap V3 pool, false
+   * otherwise
+   */
+  bool public immutable baseIsToken0;
+
+  /**
+   * @dev The Ultrachess base token
+   */
+  IERC20 public immutable baseToken;
+
+  /**
+   * @dev The Ultrachess asset token
+   */
+  IERC20 public immutable assetToken;
+
+  // Public token addresses
+  IERC20 public immutable daiToken;
+  IERC20 public immutable usdcToken;
+  IERC20 public immutable usdtToken;
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Initialization
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Initializes the contract
+   *
+   * @param curveAaveStaker_ The address of our Curve Aave staker contract
+   * @param uniswapV3Pool_ The address of the Uniswap V3 pool contract
+   * @param baseToken_ The address of the base token of the protocol
+   */
+  constructor(
+    address curveAaveStaker_,
+    address uniswapV3Pool_,
+    address baseToken_
+  ) {
+    // Validate parameters
+    require(curveAaveStaker_ != address(0), "Invalid staker");
+    require(uniswapV3Pool_ != address(0), "Invalid pool");
+    require(baseToken_ != address(0), "Invalid token");
+
+    // Translate parameters
+    address assetToken_ = address(
+      CurveAaveStaker(curveAaveStaker_).assetToken()
+    );
+
+    // Validate parameters
+    require(assetToken_ != address(0), "Invalid asset");
+
+    // Read external contracts
+    address token0 = IUniswapV3Pool(uniswapV3Pool_).token0();
+    address token1 = IUniswapV3Pool(uniswapV3Pool_).token1();
+
+    // Validate external contracts
+    require(token0 != address(0), "Invalid token0");
+    require(token1 != address(0), "Invalid token1");
+
+    // Determine token order
+    bool baseIsToken0_ = baseToken_ == token0;
+
+    // Validate external contracts
+    if (baseIsToken0_) {
+      require(token0 == baseToken_, "Invalid token0");
+      require(token1 == assetToken_, "Invalid token1");
+    } else {
+      require(token0 == assetToken_, "Invalid token0");
+      require(token1 == baseToken_, "Invalid token1");
+    }
+
+    // Initialize state
+    curveAaveStaker = CurveAaveStaker(curveAaveStaker_);
+    uniswapV3Pool = IUniswapV3Pool(uniswapV3Pool_);
+    baseToken = IERC20(baseToken_);
+    assetToken = IERC20(assetToken_);
+    baseIsToken0 = baseIsToken0_;
+    daiToken = CurveAaveStaker(curveAaveStaker_).daiToken();
+    usdcToken = CurveAaveStaker(curveAaveStaker_).usdcToken();
+    usdtToken = CurveAaveStaker(curveAaveStaker_).usdtToken();
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Implementation of {IUniV3Swapper}
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev See {IUniV3Swapper-buyTokens}
+   */
+  function buyTokens(
+    uint256[3] memory stableAmounts,
+    uint256 assetTokenAmount,
+    address recipient
+  ) public override nonReentrant returns (uint256 baseTokensReturned) {
+    // Validate parameters
+    require(recipient != address(0), "Invalid recipient");
+
+    // Receive assets
+    uint256 assetTokenBalance = _receiveAssets(stableAmounts, assetTokenAmount);
+
+    // Buy base tokens
+    baseTokensReturned = _buyBaseTokens(assetTokenBalance);
+
+    // Return base tokens
+    _returnBaseTokens(baseTokensReturned, recipient);
+
+    // Emit event
+    // slither-disable-next-line reentrancy-events
+    emit TokensBought(
+      _msgSender(),
+      recipient,
+      stableAmounts,
+      assetTokenAmount,
+      baseTokensReturned
+    );
+
+    return baseTokensReturned;
+  }
+
+  /**
+   * @dev See {IUniV3Swapper-buyTokensOneStable}
+   */
+  function buyTokensOneStable(
+    uint256 stableIndex,
+    uint256 stableAmount
+  ) public override returns (uint256 baseTokensReturned) {
+    // Validate parameters
+    require(stableIndex <= 2, "Invalid stable");
+    require(stableAmount > 0, "Invalid amount");
+
+    // Translate parameters
+    uint256[3] memory stableAmounts;
+    stableAmounts[stableIndex] = stableAmount;
+
+    // Buy base tokens
+    baseTokensReturned = buyTokens(stableAmounts, 0, _msgSender());
+
+    return baseTokensReturned;
+  }
+
+  /**
+   * @dev See {IUniV3Swapper-sellTokensForAsset}
+   */
+  function sellTokensForAsset(
+    uint256 baseTokenAmount,
+    address recipient
+  ) public override nonReentrant returns (uint256 assetTokensReturned) {
+    // Validate parameters
+    require(baseTokenAmount > 0, "Invalid amount");
+    require(recipient != address(0), "Invalid recipient");
+
+    // Receive base tokens
+    _receiveBaseTokens(baseTokenAmount);
+
+    // Sell base tokens
+    assetTokensReturned = _sellBaseTokens(baseTokenAmount);
+
+    // Return asset tokens
+    _returnAssets(assetTokensReturned, recipient);
+
+    // Dispatch event
+    // slither-disable-next-line reentrancy-events
+    emit TokensSoldForAsset(
+      _msgSender(),
+      recipient,
+      baseTokenAmount,
+      assetTokensReturned
+    );
+
+    return assetTokensReturned;
+  }
+
+  /**
+   * @dev See {IUniV3Swapper-sellTokensForStable}
+   */
+  function sellTokensForStable(
+    uint256 baseTokenAmount,
+    uint256 stableIndex,
+    address recipient
+  ) public override nonReentrant returns (uint256 stablesReturned) {
+    // Validate parameters
+    require(baseTokenAmount > 0, "Invalid amount");
+    require(stableIndex <= 2, "Invalid token");
+    require(recipient != address(0), "Invalid recipient");
+
+    // Receive base tokens
+    _receiveBaseTokens(baseTokenAmount);
+
+    // Sell base tokens
+    uint256 assetTokensReceived = _sellBaseTokens(baseTokenAmount);
+
+    // Return stablecoins
+    _returnStables(assetTokensReceived, stableIndex, recipient);
+
+    // Dispatch event
+    // slither-disable-next-line reentrancy-events
+    emit TokensSoldForStable(
+      _msgSender(),
+      recipient,
+      stableIndex,
+      baseTokenAmount,
+      assetTokensReceived,
+      stablesReturned
+    );
+
+    return stablesReturned;
+  }
+
+  /**
+   * @dev See {IUniV3Swapper-exitOneStable}
+   */
+  function exitOneStable(
+    uint256 stableIndex
+  ) public override returns (uint256 stablesReturned) {
+    // Read state
+    uint256 baseTokenAmount = baseToken.balanceOf(_msgSender());
+
+    // Swap everything
+    stablesReturned = sellTokensForStable(
+      baseTokenAmount,
+      stableIndex,
+      _msgSender()
+    );
+
+    return stablesReturned;
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Implementation of {IUniswapV3SwapCallback}
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev See {IUniswapV3SwapCallback-uniswapV3SwapCallback}
+   *
+   * This function is called to the sender after a swap is executed on
+   * Uniswap V3.
+   *
+   * The pool tokens owed for the swap must be payed. The caller of this
+   * method must be checked to be a UniswapV3Pool deployed by the canonical
+   * UniswapV3Factory.
+   *
+   * amount0Delta and amount1Delta can both be 0 if no tokens were swapped.
+   */
+  function uniswapV3SwapCallback(
+    // slither-disable-next-line similar-names
+    int256 amount0Delta,
+    int256 amount1Delta,
+    bytes calldata
+  ) public override {
+    // Validate caller
+    require(_msgSender() == address(uniswapV3Pool), "Invalid caller");
+
+    // Pay fees
+    if (amount0Delta > 0) {
+      IERC20(IUniswapV3Pool(_msgSender()).token0()).safeTransfer(
+        _msgSender(),
+        uint256(amount0Delta)
+      );
+    }
+    if (amount1Delta > 0) {
+      IERC20(IUniswapV3Pool(_msgSender()).token1()).safeTransfer(
+        _msgSender(),
+        uint256(amount1Delta)
+      );
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Private functions
+  //////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @dev Procure asset tokens and stablecoins from the sender
+   *
+   * @param stableAmounts Amounts of stablecoins to transfer
+   * @param assetTokenAmount Amount of asset tokens to transfer
+   *
+   * @return assetTokenBalance Balance of asset tokens in this contract
+   */
+  function _receiveAssets(
+    uint256[3] memory stableAmounts,
+    uint256 assetTokenAmount
+  ) private returns (uint256 assetTokenBalance) {
+    // Call external contracts
+    bool hasStable = false;
+    if (stableAmounts[0] > 0) {
+      daiToken.safeTransferFrom(_msgSender(), address(this), stableAmounts[0]);
+      daiToken.safeIncreaseAllowance(
+        address(curveAaveStaker),
+        stableAmounts[0]
+      );
+      hasStable = true;
+    }
+    if (stableAmounts[1] > 0) {
+      usdcToken.safeTransferFrom(_msgSender(), address(this), stableAmounts[1]);
+      usdcToken.safeIncreaseAllowance(
+        address(curveAaveStaker),
+        stableAmounts[1]
+      );
+      hasStable = true;
+    }
+    if (stableAmounts[2] > 0) {
+      usdtToken.safeTransferFrom(_msgSender(), address(this), stableAmounts[2]);
+      usdtToken.safeIncreaseAllowance(
+        address(curveAaveStaker),
+        stableAmounts[2]
+      );
+      hasStable = true;
+    }
+    if (assetTokenAmount > 0) {
+      assetToken.safeTransferFrom(
+        _msgSender(),
+        address(this),
+        assetTokenAmount
+      );
+    }
+
+    // Stake stablecoins, if any, in Curve Aave pool
+    uint256 mintedAssetTokens = hasStable
+      ? curveAaveStaker.stakeTokens(stableAmounts, address(this))
+      : 0;
+
+    return assetTokenAmount.add(mintedAssetTokens);
+  }
+
+  /**
+   * @dev Procure base tokens from the sender
+   *
+   * @param baseTokenAmount Amount of base tokens to transfer
+   */
+  function _receiveBaseTokens(uint256 baseTokenAmount) private {
+    // Call external contracts
+    baseToken.safeTransferFrom(_msgSender(), address(this), baseTokenAmount);
+  }
+
+  /**
+   * @dev Buy base tokens with asset tokens
+   *
+   * @param assetTokenAmount Amount of asset tokens to spend
+   *
+   * @return baseTokensReturned Amount of base tokens received
+   */
+  function _buyBaseTokens(
+    uint256 assetTokenAmount
+  ) private returns (uint256 baseTokensReturned) {
+    // Approve Uniswap V3 pool to spend asset tokens
+    IERC20(assetToken).safeIncreaseAllowance(
+      address(uniswapV3Pool),
+      assetTokenAmount
+    );
+
+    //
+    // Swap asset tokens for base tokens
+    //
+    // A note about amount0 and amount1:
+    //
+    // amount0 is the delta of the balance of token0 of the pool
+    // amount1 is the delta of the balance of token1 of the pool
+    //
+    // Amounts are exact when negative, minimum when positive.
+    //
+    bool zeroForOne = baseIsToken0 ? false : true;
+    (int256 amount0, int256 amount1) = uniswapV3Pool.swap(
+      address(this),
+      zeroForOne,
+      SafeCast.toInt256(assetTokenAmount),
+      baseIsToken0 ? MAX_SQRT_RATIO - 1 : MIN_SQRT_RATIO + 1, // TODO
+      ""
+    );
+
+    // Calculate base token amount
+    baseTokensReturned = baseIsToken0
+      ? SafeCast.toUint256(-amount0)
+      : SafeCast.toUint256(-amount1);
+
+    return baseTokensReturned;
+  }
+
+  /**
+   * @dev Sell base tokens for asset tokens
+   *
+   * @param baseTokenAmount Amount of base tokens to spend
+   *
+   * @return assetTokensReturned Amount of asset tokens received
+   */
+  function _sellBaseTokens(
+    uint256 baseTokenAmount
+  ) private returns (uint256 assetTokensReturned) {
+    // Approve Uniswap V3 pool to spend base tokens
+    baseToken.safeIncreaseAllowance(address(uniswapV3Pool), baseTokenAmount);
+
+    //
+    // Swap base tokens for asset tokens
+    //
+    // A note about amount0 and amount1:
+    //
+    // amount0 is the delta of the balance of token0 of the pool
+    // amount1 is the delta of the balance of token1 of the pool
+    //
+    // Amounts are exact when negative, minimum when positive.
+    //
+    bool zeroForOne = baseIsToken0 ? true : false;
+    (int256 amount0, int256 amount1) = uniswapV3Pool.swap(
+      address(this),
+      zeroForOne,
+      SafeCast.toInt256(baseTokenAmount),
+      baseIsToken0 ? MIN_SQRT_RATIO + 1 : MAX_SQRT_RATIO - 1, // TODO
+      ""
+    );
+
+    // Calculate asset token amount
+    assetTokensReturned = baseIsToken0
+      ? SafeCast.toUint256(-amount1)
+      : SafeCast.toUint256(-amount0);
+
+    return assetTokensReturned;
+  }
+
+  /**
+   * @dev Return base tokens to the recipient
+   *
+   * @param baseTokenAmount Amount of base tokens to transfer
+   * @param recipient Address to transfer base tokens to
+   */
+  function _returnBaseTokens(
+    uint256 baseTokenAmount,
+    address recipient
+  ) private {
+    // Transfer tokens to the recipient
+    if (baseTokenAmount > 0) {
+      baseToken.safeTransfer(recipient, baseTokenAmount);
+    }
+  }
+
+  /**
+   * @dev Return asset tokens to the recipient
+   *
+   * @param assetTokenAmount Amount of asset tokens to transfer
+   * @param recipient Address to transfer asset tokens to
+   */
+  function _returnAssets(uint256 assetTokenAmount, address recipient) private {
+    // Transfer tokens to the recipient
+    if (assetTokenAmount > 0) {
+      assetToken.safeTransfer(recipient, assetTokenAmount);
+    }
+  }
+
+  /**
+   * @dev Return stablecoins to the recipient
+   *
+   * @param assetTokenAmount Amount of asset tokens to unstake for stablecoins
+   * @param stableIndex Index of stablecoin to unstake
+   * @param recipient Address to transfer stablecoins to
+   *
+   * @return stablesReturned Amount of stablecoins returned
+   */
+  function _returnStables(
+    uint256 assetTokenAmount,
+    uint256 stableIndex,
+    address recipient
+  ) private returns (uint256 stablesReturned) {
+    // Approve Curve Aave staker to spend asset tokens
+    IERC20(assetToken).safeIncreaseAllowance(
+      address(curveAaveStaker),
+      assetTokenAmount
+    );
+
+    // Unstake tokens from Curve Aave pool
+    stablesReturned = curveAaveStaker.unstakeOneStable(
+      assetTokenAmount,
+      stableIndex,
+      recipient
+    );
+
+    // Call external contracts
+    if (stableIndex == 0) {
+      daiToken.safeTransfer(recipient, stablesReturned);
+    } else if (stableIndex == 1) {
+      usdcToken.safeTransfer(recipient, stablesReturned);
+    } else if (stableIndex == 2) {
+      usdtToken.safeTransfer(recipient, stablesReturned);
+    }
+
+    return stablesReturned;
+  }
+}

--- a/contracts/src/utils/math/LiquidityMath.sol
+++ b/contracts/src/utils/math/LiquidityMath.sol
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/contracts
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+pragma solidity 0.8.16;
+
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {SafeMath} from "@openzeppelin/contracts/utils/math/SafeMath.sol";
+
+/**
+ * @dev Liquidity math for computing the optimal one-sided supply to a
+ * liquidity pool
+ */
+contract LiquidityMath {
+  using SafeMath for uint256;
+
+  /**
+   * @dev Compute swap amount needed for adding liquidity to a pool in the
+   * absence of concentrated liquidity (such as a Uniswap V2 pool)
+   *
+   * The goal is to find the optimal swapAmountA to get a corresponding amount
+   * of asset B, so that the proportion of assets the user holds is equal to
+   * the proportion of assets in reserves after swap.
+   *
+   * Calculation:
+   *
+   * The initial constant product is given by:
+   *
+   *   k = reserveA * reserveB
+   *
+   * The swap fee is deducted from the input asset amount, so the new reserveB
+   * should satisfy:
+   *
+   *   k = (reserveA + (1 - fee) * swapA) * reserveB'
+   *
+   * This means the user will receive an amount of asset B equal to:
+   *
+   *   rcvAmountB = reserveB - reserveB'
+   *
+   *              = reserveB - k / (reserveA + (1 - fee) * swapA)
+   *
+   *              = reserveB - reserveA * reserveB / (reserveA + (1 - fee) * swapAmountA)
+   *
+   *              = (1 - fee) * reserveB * swapAmountA / (reserveA + (1 - fee) * swapAmountA)
+   *
+   * The optimal swapAmountA should satisfy the equality constraint on the
+   * user's asset ratio and the reserve's asset ratio:
+   *
+   *   (amountA - swapAmountA) / (reserveA + swapAmountA) = rcvAmountB / reserveB'
+   *
+   * Substituting known variables rcvAmountB and reserveB' and rearranging the
+   * equation yields a quadratic equation in variable swapAmountA as follows:
+   *
+   *   (1 - fee) * (swapAmountA)^2 + ((2 - fee) * reserveA) * swapAmountA - amountA * reserveA = 0
+   *
+   * Solving the above equation for a non-negative root yields:
+   *
+   *   swapAmountA =
+   *     sqrt(((2 - fee) * reserveA)^2 + 4 * (1 - fee) * amountA * reserveA) - (2 - fee) * reserveA
+   *       / (2 * (1 - fee))
+   *
+   * The fee is represented in hundredths of a bip, so we can avoid floating
+   * point numbers by multiplying both the numerator and denominator by 1E6:
+   *
+   * swapAmountA =
+   *   sqrt((2E6 - fee)^2 * reserveA^2 + 4 * 1E6 * (1E6 - fee) * amountA * reserveA) - (2E6 - fee) * reserveA
+   *     / (2 * (1E6 - fee))
+   *
+   * Credit to Zapper Finance for the above derivation.
+   *
+   * @param reserveA The reserve of token A
+   * @param amountA The amount of token A to add
+   * @param swapfee The swap fee of the pool, denominated in hundredths of a bip
+   *
+   * @return swapAmountA The amount of token A to swap for token B
+   */
+  function computeSwapAmountV2(
+    uint256 reserveA,
+    uint256 amountA,
+    uint24 swapfee
+  ) public pure returns (uint256 swapAmountA) {
+    // prettier-ignore
+    swapAmountA = (
+      Math.sqrt(
+        (
+          uint256(2E6).sub(swapfee).mul(
+            uint256(2E6).sub(swapfee)
+          ).mul(
+            reserveA
+          ).mul(
+            reserveA
+          )
+        ).add(
+          uint256(4).mul(
+            uint256(1E6)
+          ).mul(
+            uint256(1E6).sub(swapfee)
+          ).mul(
+            amountA
+          ).mul(
+            reserveA
+          )
+        )
+      ).sub(
+        (
+          uint256(2E6).sub(swapfee)
+        ).mul(
+          reserveA
+        )
+      )
+    ).div(
+      uint256(2).mul(
+        uint256(1E6).sub(swapfee)
+      )
+    );
+
+    return swapAmountA;
+  }
+}

--- a/deploy/003_fund_deployer.ts
+++ b/deploy/003_fund_deployer.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/contracts
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+import "hardhat-deploy";
+
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+
+import { USDC_TOKEN_CONTRACT } from "../src/contracts/testing";
+
+//
+// Fund the deployer with 1 test USDC
+//
+
+const func: DeployFunction = async (hardhat_re: HardhatRuntimeEnvironment) => {
+  const { deployments, ethers, getNamedAccounts } = hardhat_re;
+
+  const { execute } = deployments;
+  const { deployer } = await getNamedAccounts();
+
+  //////////////////////////////////////////////////////////////////////////////
+  //
+  // Mint the deployer one USDC to initialize the Uniswap V3 liquidity pool
+  //
+  //////////////////////////////////////////////////////////////////////////////
+
+  // Amount to mint
+  const USDC_AMOUNT = ethers.utils.parseUnits("1", 6); // 1 USDC
+
+  // Calculate the fee consumed by the Curve Aave pool
+  const CURVE_AAVE_FEE_BIPS = 3; // 0.03%
+  const CURVE_AAVE_FEE_USDC = USDC_AMOUNT.mul(CURVE_AAVE_FEE_BIPS).div(10_000);
+
+  //
+  // Mint 1 USDC
+  //
+
+  console.log("Minting 1 USDC to deployer");
+
+  await execute(
+    USDC_TOKEN_CONTRACT,
+    {
+      from: deployer,
+      log: true,
+    },
+    "mint",
+    deployer,
+    USDC_AMOUNT.add(CURVE_AAVE_FEE_USDC)
+  );
+};
+
+module.exports = func;
+module.exports.tags = ["FundDeployer"];

--- a/deploy/100_deploy_routes.ts
+++ b/deploy/100_deploy_routes.ts
@@ -1,0 +1,401 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/contracts
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+/* eslint no-empty: "off" */
+
+import { ethers } from "ethers";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction, DeployOptions } from "hardhat-deploy/types";
+
+import { getAddressBook, writeAddress } from "../src/addressBook";
+import { FEE_AMOUNT } from "../src/constants";
+import {
+  ASSET_TOKEN_CONTRACT,
+  BASE_TOKEN_CONTRACT,
+  CURVE_AAVE_POOLER_CONTRACT,
+  CURVE_AAVE_STAKER_CONTRACT,
+  curveAaveStakerAbi,
+  LP_SFT_CONTRACT,
+  UNI_V3_POOL_FACTORY_CONTRACT,
+  UNI_V3_POOLER_CONTRACT,
+  UNI_V3_STAKER_CONTRACT,
+  UNI_V3_SWAPPER_CONTRACT,
+} from "../src/contracts/dapp";
+import { erc20Abi, uniswapV3PoolAbi } from "../src/contracts/depends";
+import { AddressBook } from "../src/interfaces";
+import { encodePriceSqrt } from "../src/utils/fixedMath";
+
+//
+// Dapp parameters
+//
+// TODO: Relocate me
+//
+
+// Initial reward for the LP NFT staking incentive
+const REWARD_AMOUNT = ethers.utils.parseUnits("1000", 18); // 1,000 base tokens
+
+//
+// Dapp deployment
+//
+
+const func: DeployFunction = async (hardhat_re: HardhatRuntimeEnvironment) => {
+  const { deployments, ethers, getNamedAccounts } = hardhat_re;
+  const { deployer } = await getNamedAccounts();
+
+  const [deployerSigner] = await ethers.getSigners();
+
+  const opts: DeployOptions = {
+    deterministicDeployment: true,
+    from: deployer,
+    log: true,
+  };
+
+  // Get the network name
+  const networkName = hardhat_re.network.name;
+
+  // Load the contract addresses
+  const addressBook: AddressBook = await getAddressBook(networkName);
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Deploy contracts
+  //////////////////////////////////////////////////////////////////////////////
+
+  // Deploy base token
+  if (addressBook.baseToken) {
+    console.log(`Using ${BASE_TOKEN_CONTRACT} at ${addressBook.baseToken}`);
+  } else {
+    console.log(`Deploying ${BASE_TOKEN_CONTRACT}`);
+    const tx = await deployments.deploy(BASE_TOKEN_CONTRACT, {
+      ...opts,
+      args: [
+        deployer, // owner
+      ],
+    });
+    addressBook.baseToken = tx.address;
+  }
+
+  // Deploy asset token
+  if (addressBook.assetToken) {
+    console.log(`Using ${ASSET_TOKEN_CONTRACT} at ${addressBook.assetToken}`);
+  } else {
+    console.log(`Deploying ${ASSET_TOKEN_CONTRACT}`);
+    const tx = await deployments.deploy(ASSET_TOKEN_CONTRACT, {
+      ...opts,
+      args: [
+        deployer, // owner
+      ],
+    });
+    addressBook.assetToken = tx.address;
+  }
+
+  // Deploy LP SFT contract
+  if (addressBook.lpSft) {
+    console.log(`Using ${LP_SFT_CONTRACT} at ${addressBook.lpSft}`);
+  } else {
+    console.log(`Deploying ${LP_SFT_CONTRACT}`);
+    const tx = await deployments.deploy(LP_SFT_CONTRACT, {
+      ...opts,
+      args: [
+        deployer, // owner
+        addressBook.uniswapV3NftManager, // uniswapV3NftManager
+      ],
+    });
+    addressBook.lpSft = tx.address;
+  }
+
+  // Deploy CurveAavePooler
+  if (addressBook.curveAavePooler) {
+    console.log(
+      `Using ${CURVE_AAVE_POOLER_CONTRACT} at ${addressBook.curveAavePooler}`
+    );
+  } else {
+    console.log(`Deploying ${CURVE_AAVE_POOLER_CONTRACT}`);
+    const tx = await deployments.deploy(CURVE_AAVE_POOLER_CONTRACT, {
+      ...opts,
+      args: [
+        addressBook.curveAavePool, // curveAavePool
+      ],
+    });
+    addressBook.curveAavePooler = tx.address;
+  }
+
+  // Deploy CurveAaveStaker
+  if (addressBook.curveAaveStaker) {
+    console.log(
+      `Using ${CURVE_AAVE_STAKER_CONTRACT} at ${addressBook.curveAaveStaker}`
+    );
+  } else {
+    console.log(`Deploying ${CURVE_AAVE_STAKER_CONTRACT}`);
+    const tx = await deployments.deploy(CURVE_AAVE_STAKER_CONTRACT, {
+      ...opts,
+      args: [
+        addressBook.curveAavePooler, // curveAavePooler
+        addressBook.curveAaveGauge, // curveAaveGauge
+        addressBook.assetToken, // assetToken
+      ],
+    });
+    addressBook.curveAaveStaker = tx.address;
+  }
+
+  // Deploy Uniswap V3 pool factory
+  if (addressBook.uniV3PoolFactory) {
+    console.log(
+      `Using ${UNI_V3_POOL_FACTORY_CONTRACT} at ${addressBook.uniV3PoolFactory}`
+    );
+  } else {
+    console.log(`Deploying ${UNI_V3_POOL_FACTORY_CONTRACT}`);
+    const tx = await deployments.deploy(UNI_V3_POOL_FACTORY_CONTRACT, {
+      ...opts,
+      args: [
+        addressBook.uniswapV3Factory, // factory
+        addressBook.baseToken, // baseToken
+        addressBook.assetToken, // assetToken
+        FEE_AMOUNT.HIGH, // swapFee
+      ],
+    });
+    addressBook.uniV3PoolFactory = tx.address;
+  }
+
+  // Read Uniswap V3 pool address
+  const uniswapV3PoolAddress = await deployments.read(
+    UNI_V3_POOL_FACTORY_CONTRACT,
+    "uniswapV3Pool"
+  );
+
+  // Deploy UniV3Swapper
+  if (addressBook.uniV3Swapper) {
+    console.log(
+      `Using ${UNI_V3_SWAPPER_CONTRACT} at ${addressBook.uniV3Swapper}`
+    );
+  } else {
+    console.log(`Deploying ${UNI_V3_SWAPPER_CONTRACT}`);
+    const tx = await deployments.deploy(UNI_V3_SWAPPER_CONTRACT, {
+      ...opts,
+      args: [
+        addressBook.curveAaveStaker, // curveAaveStaker
+        uniswapV3PoolAddress, // uniswapV3Pool
+        addressBook.baseToken, // baseToken
+      ],
+    });
+    addressBook.uniV3Swapper = tx.address;
+  }
+
+  // Deploy UniV3Pooler
+  if (addressBook.uniV3Pooler) {
+    console.log(
+      `Using ${UNI_V3_POOLER_CONTRACT} at ${addressBook.uniV3Pooler}`
+    );
+  } else {
+    console.log(`Deploying ${UNI_V3_POOLER_CONTRACT}`);
+    const tx = await deployments.deploy(UNI_V3_POOLER_CONTRACT, {
+      ...opts,
+      args: [
+        addressBook.uniV3Swapper, // uniV3Swapper
+        addressBook.uniswapV3NftManager, // uniswapV3NftManager
+      ],
+    });
+    addressBook.uniV3Pooler = tx.address;
+  }
+
+  // Deploy UniV3Staker
+  if (addressBook.uniV3Staker) {
+    console.log(
+      `Using ${UNI_V3_STAKER_CONTRACT} at ${addressBook.uniV3Staker}`
+    );
+  } else {
+    console.log(`Deploying ${UNI_V3_STAKER_CONTRACT}`);
+    const tx = await deployments.deploy(UNI_V3_STAKER_CONTRACT, {
+      ...opts,
+      args: [
+        deployer, // owner
+        addressBook.uniV3Pooler, // uniV3Pooler
+        addressBook.uniswapV3Staker, // uniswapV3Staker
+        addressBook.lpSft, // lpSft
+      ],
+    });
+    addressBook.uniV3Staker = tx.address;
+  }
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Setup contracts
+  //////////////////////////////////////////////////////////////////////////////
+
+  // Grant role of issuer to the Curve Aave staker
+  const ASSET_ISSUER_ROLE = await deployments.read(
+    ASSET_TOKEN_CONTRACT,
+    "ISSUER_ROLE"
+  );
+  if (
+    !(await deployments.read(
+      ASSET_TOKEN_CONTRACT,
+      "hasRole",
+      ASSET_ISSUER_ROLE,
+      addressBook.curveAaveStaker
+    ))
+  ) {
+    console.log(
+      `Granting issuer of ${ASSET_TOKEN_CONTRACT} to ${CURVE_AAVE_STAKER_CONTRACT}`
+    );
+    await deployments.execute(
+      ASSET_TOKEN_CONTRACT,
+      opts,
+      "grantRole",
+      ASSET_ISSUER_ROLE,
+      addressBook.curveAaveStaker
+    );
+  } else {
+    console.log(
+      `Issuer of ${ASSET_TOKEN_CONTRACT} already granted to ${CURVE_AAVE_STAKER_CONTRACT}`
+    );
+  }
+
+  // Grant role of issuer to the Uniswap V3 staker
+  const LP_SFT_ISSUER_ROLE = await deployments.read(
+    LP_SFT_CONTRACT,
+    "ISSUER_ROLE"
+  );
+  if (
+    !(await deployments.read(
+      LP_SFT_CONTRACT,
+      "hasRole",
+      LP_SFT_ISSUER_ROLE,
+      addressBook.uniV3Staker
+    ))
+  ) {
+    console.log(
+      `Granting issuer of ${LP_SFT_CONTRACT} to ${UNI_V3_STAKER_CONTRACT}`
+    );
+    await deployments.execute(
+      LP_SFT_CONTRACT,
+      opts,
+      "grantRole",
+      LP_SFT_ISSUER_ROLE,
+      addressBook.uniV3Staker
+    );
+  } else {
+    console.log(
+      `Issuer of ${LP_SFT_CONTRACT} already granted to ${UNI_V3_STAKER_CONTRACT}`
+    );
+  }
+
+  // Approve UniV3 staker spending USDC
+  console.log(`Approving ${UNI_V3_STAKER_CONTRACT} to spend base token`);
+  await deployments.execute(
+    BASE_TOKEN_CONTRACT,
+    opts,
+    "approve",
+    addressBook.uniV3Staker,
+    REWARD_AMOUNT
+  );
+
+  // Set up the Uniswap V3 staker
+  console.log(`Setting up ${UNI_V3_STAKER_CONTRACT}`);
+  await deployments.execute(
+    UNI_V3_STAKER_CONTRACT,
+    opts,
+    "createIncentive",
+    REWARD_AMOUNT
+  );
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Initialize the Uniswap V3 pool
+  //////////////////////////////////////////////////////////////////////////////
+
+  const USDC_AMOUNT = ethers.utils.parseUnits("1", 6); // 1 USDC
+  const BASE_TOKEN_AMOUNT = ethers.utils.parseUnits("1", 18); // 1 base token
+  const CURVE_AAVE_FEE_BIPS = 3; // Curve Aave pool fee is 0.03% (3 bips)
+
+  //
+  // Construct the contracts
+  //
+
+  const curveAaveStakerContract = new ethers.Contract(
+    addressBook.curveAaveStaker,
+    curveAaveStakerAbi,
+    deployerSigner
+  );
+  const uniswapV3PoolContract = new ethers.Contract(
+    uniswapV3PoolAddress,
+    uniswapV3PoolAbi,
+    deployerSigner
+  );
+  const usdcTokenContract = new ethers.Contract(
+    addressBook.usdcToken,
+    erc20Abi,
+    deployerSigner
+  );
+
+  //
+  // Allow Curve Aave staker to spend USDC if needed
+  //
+
+  const allowance = await usdcTokenContract.allowance(
+    deployer,
+    addressBook.curveAaveStaker
+  );
+
+  if (allowance.lt(USDC_AMOUNT)) {
+    console.log(`Approving ${CURVE_AAVE_STAKER_CONTRACT} to spend USDC`);
+
+    const approveTx: ethers.ContractTransaction =
+      await usdcTokenContract.approve(
+        addressBook.curveAaveStaker,
+        USDC_AMOUNT.sub(allowance)
+      );
+
+    await approveTx.wait();
+  }
+
+  //
+  // Get price of ultra3CRV in USDC
+  //
+
+  const gaugeTokenAmount =
+    await curveAaveStakerContract.callStatic.stakeOneStable(1, USDC_AMOUNT);
+
+  const poolFee = gaugeTokenAmount.mul(CURVE_AAVE_FEE_BIPS).div(10_000);
+
+  const ultra3CRVPrice = gaugeTokenAmount.add(poolFee);
+
+  //
+  // Get pool token order
+  //
+
+  const baseIsToken0 = await deployments.read(
+    UNI_V3_POOLER_CONTRACT,
+    "baseIsToken0"
+  );
+
+  //
+  // Initialize the Uniswap V3 pool
+  //
+
+  console.log(
+    `Initializing Uniswap V3 pool with ultra3CRV price ${ultra3CRVPrice}`
+  );
+
+  const initTx: ethers.ContractTransaction =
+    await uniswapV3PoolContract.initialize(
+      // The initial sqrt price [sqrt(amountToken1/amountToken0)] as a Q64.96 value
+      encodePriceSqrt(
+        baseIsToken0 ? ultra3CRVPrice : BASE_TOKEN_AMOUNT,
+        baseIsToken0 ? BASE_TOKEN_AMOUNT : ultra3CRVPrice
+      )
+    );
+
+  await initTx.wait();
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Record addresses
+  //////////////////////////////////////////////////////////////////////////////
+
+  writeAddress(networkName, "UniswapV3Pool", uniswapV3PoolAddress);
+};
+
+export default func;
+func.tags = ["TokenRoutes"];

--- a/deploy/101_mint_lp_nft.ts
+++ b/deploy/101_mint_lp_nft.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/contracts
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+/* eslint no-empty: "off" */
+
+import "hardhat-deploy";
+
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+
+import { getAddressBook } from "../src/addressBook";
+import {
+  BASE_TOKEN_CONTRACT,
+  UNI_V3_POOLER_CONTRACT,
+} from "../src/contracts/dapp";
+import { USDC_TOKEN_CONTRACT } from "../src/contracts/testing";
+import { AddressBook } from "../src/interfaces";
+
+//
+// Mint the deployer an LP NFT
+//
+
+const func: DeployFunction = async (hardhat_re: HardhatRuntimeEnvironment) => {
+  const { deployments, ethers, getNamedAccounts } = hardhat_re;
+
+  const { execute } = deployments;
+  const { deployer } = await getNamedAccounts();
+
+  // Get the network name
+  const networkName = hardhat_re.network.name;
+
+  // Load the contract addresses
+  const addressBook: AddressBook = await getAddressBook(networkName);
+
+  //////////////////////////////////////////////////////////////////////////////
+  //
+  // Mint the deployer an LP NFT to initialize the Uniswap V3 liquidity pool
+  //
+  //////////////////////////////////////////////////////////////////////////////
+
+  // Amount to mint
+  const USDC_AMOUNT = ethers.utils.parseUnits("1", 6); // 1 USDC
+  const BASE_TOKEN_AMOUNT = ethers.utils.parseUnits("1", 18); // 1 token
+
+  // Calculate the fee consumed by the Curve Aave pool
+  const CURVE_AAVE_FEE_BIPS = 3; // 0.03%
+  const CURVE_AAVE_FEE_USDC = USDC_AMOUNT.mul(CURVE_AAVE_FEE_BIPS).div(10_000);
+
+  //
+  // Approve deployer's USDC
+  //
+
+  console.log("Approving deployer's USDC");
+
+  await execute(
+    USDC_TOKEN_CONTRACT,
+    {
+      from: deployer,
+      log: true,
+    },
+    "approve",
+    addressBook.uniV3Pooler,
+    USDC_AMOUNT.add(CURVE_AAVE_FEE_USDC)
+  );
+
+  //
+  // Approve deployer's base token
+  //
+
+  console.log("Approving deployer's base token");
+
+  await execute(
+    BASE_TOKEN_CONTRACT,
+    {
+      from: deployer,
+      log: true,
+    },
+    "approve",
+    addressBook.uniV3Pooler,
+    BASE_TOKEN_AMOUNT
+  );
+
+  //
+  // Mint LP NFT
+  //
+
+  console.log("Minting LP NFT to deployer");
+
+  await execute(
+    UNI_V3_POOLER_CONTRACT,
+    {
+      from: deployer,
+      log: true,
+    },
+    "mintNFTImbalance",
+    [0, USDC_AMOUNT.add(CURVE_AAVE_FEE_USDC), 0], // DAI, USDC, USDT
+    BASE_TOKEN_AMOUNT,
+    deployer
+  );
+};
+
+module.exports = func;
+module.exports.tags = ["MintLpNft"];

--- a/src/addressBook.ts
+++ b/src/addressBook.ts
@@ -14,6 +14,17 @@ import * as hardhat from "hardhat";
 import goerliAddresses from "./addresses/goerli.json";
 import polygonMainnetAddresses from "./addresses/polygon_mainnet.json";
 import {
+  ASSET_TOKEN_CONTRACT,
+  BASE_TOKEN_CONTRACT,
+  CURVE_AAVE_POOLER_CONTRACT,
+  CURVE_AAVE_STAKER_CONTRACT,
+  LP_SFT_CONTRACT,
+  UNI_V3_POOL_FACTORY_CONTRACT,
+  UNI_V3_POOLER_CONTRACT,
+  UNI_V3_STAKER_CONTRACT,
+  UNI_V3_SWAPPER_CONTRACT,
+} from "./contracts/dapp";
+import {
   AAVE_ADDRESS_CONFIG_CONTRACT,
   AAVE_INCENTIVES_CONTROLLER_CONTRACT,
   AAVE_INTEREST_RATE_STRATEGY_CONTRACT,
@@ -173,6 +184,11 @@ async function getAddressBook(networkName: string): Promise<AddressBook> {
       ADAI_VARIABLE_DEBT_TOKEN_CONTRACT,
       networkName
     ),
+    assetToken: await getContractAddress(
+      "assetToken",
+      ASSET_TOKEN_CONTRACT,
+      networkName
+    ),
     ausdcStableDebtToken: await getContractAddress(
       "ausdcStableDebtToken",
       AUSDC_STABLE_DEBT_TOKEN_CONTRACT,
@@ -213,6 +229,11 @@ async function getAddressBook(networkName: string): Promise<AddressBook> {
       AUSDT_VARIABLE_DEBT_TOKEN_CONTRACT,
       networkName
     ),
+    baseToken: await getContractAddress(
+      "baseToken",
+      BASE_TOKEN_CONTRACT,
+      networkName
+    ),
     crvController: await getContractAddress(
       "crvController",
       CRV_CONTROLLER_CONTRACT,
@@ -248,11 +269,22 @@ async function getAddressBook(networkName: string): Promise<AddressBook> {
       CURVE_AAVE_POOL_CONTRACT,
       networkName
     ),
+    curveAavePooler: await getContractAddress(
+      "curveAavePooler",
+      CURVE_AAVE_POOLER_CONTRACT,
+      networkName
+    ),
+    curveAaveStaker: await getContractAddress(
+      "curveAaveStaker",
+      CURVE_AAVE_STAKER_CONTRACT,
+      networkName
+    ),
     daiToken: await getContractAddress(
       "daiToken",
       DAI_TOKEN_CONTRACT,
       networkName
     ),
+    lpSft: await getContractAddress("lpSft", LP_SFT_CONTRACT, networkName),
     uniswapV3Factory: await getContractAddress(
       "uniswapV3Factory",
       UNISWAP_V3_FACTORY_CONTRACT,
@@ -276,6 +308,26 @@ async function getAddressBook(networkName: string): Promise<AddressBook> {
     uniswapV3Staker: await getContractAddress(
       "uniswapV3Staker",
       UNISWAP_V3_STAKER_CONTRACT,
+      networkName
+    ),
+    uniV3Pooler: await getContractAddress(
+      "uniV3Pooler",
+      UNI_V3_POOLER_CONTRACT,
+      networkName
+    ),
+    uniV3PoolFactory: await getContractAddress(
+      "uniV3PoolFactory",
+      UNI_V3_POOL_FACTORY_CONTRACT,
+      networkName
+    ),
+    uniV3Staker: await getContractAddress(
+      "uniV3Staker",
+      UNI_V3_STAKER_CONTRACT,
+      networkName
+    ),
+    uniV3Swapper: await getContractAddress(
+      "uniV3Swapper",
+      UNI_V3_SWAPPER_CONTRACT,
       networkName
     ),
     usdcToken: await getContractAddress(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/contracts
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+//
+// Constants
+//
+
+const enum FEE_AMOUNT {
+  LOW = 500, // 0.05%
+  MEDIUM = 3_000, // 0.3%
+  HIGH = 10_000, // 1%
+}
+
+const TICK_SPACINGS: { [amount in FEE_AMOUNT]: number } = {
+  [FEE_AMOUNT.LOW]: 10,
+  [FEE_AMOUNT.MEDIUM]: 60,
+  [FEE_AMOUNT.HIGH]: 200,
+};
+
+export { FEE_AMOUNT, TICK_SPACINGS };

--- a/src/contracts/dapp.ts
+++ b/src/contracts/dapp.ts
@@ -6,7 +6,43 @@
  * See the file LICENSE for more information.
  */
 
-// Contract names (sort by constant)
-const UNI_V3_POOL_FACTORY_CONTRACT = "UniV3PoolFactory";
+// Contract ABIs and artifacts (sort by path)
+import baseTokenAbi from "../abi/contracts/src/token/CHESS.sol/CHESS.json";
+import lpSftAbi from "../abi/contracts/src/token/LpSft.sol/LpSft.json";
+import curveAavePoolerAbi from "../abi/contracts/src/token/routes/CurveAavePooler.sol/CurveAavePooler.json";
+import curveAaveStakerAbi from "../abi/contracts/src/token/routes/CurveAaveStaker.sol/CurveAaveStaker.json";
+import uniV3PoolerAbi from "../abi/contracts/src/token/routes/UniV3Pooler.sol/UniV3Pooler.json";
+import uniV3StakerAbi from "../abi/contracts/src/token/routes/UniV3Staker.sol/UniV3Staker.json";
+import uniV3SwapperAbi from "../abi/contracts/src/token/routes/UniV3Swapper.sol/UniV3Swapper.json";
+import assetTokenAbi from "../abi/contracts/src/token/Ultra3CRV.sol/Ultra3CRV.json";
 
-export { UNI_V3_POOL_FACTORY_CONTRACT };
+// Contract names (sort by constant)
+const ASSET_TOKEN_CONTRACT = "Ultra3CRV";
+const BASE_TOKEN_CONTRACT = "CHESS";
+const CURVE_AAVE_POOLER_CONTRACT = "CurveAavePooler";
+const CURVE_AAVE_STAKER_CONTRACT = "CurveAaveStaker";
+const LP_SFT_CONTRACT = "LpSft";
+const UNI_V3_POOL_FACTORY_CONTRACT = "UniV3PoolFactory";
+const UNI_V3_POOLER_CONTRACT = "UniV3Pooler";
+const UNI_V3_STAKER_CONTRACT = "UniV3Staker";
+const UNI_V3_SWAPPER_CONTRACT = "UniV3Swapper";
+
+export {
+  baseTokenAbi,
+  lpSftAbi,
+  curveAavePoolerAbi,
+  curveAaveStakerAbi,
+  uniV3PoolerAbi,
+  uniV3StakerAbi,
+  uniV3SwapperAbi,
+  assetTokenAbi,
+  ASSET_TOKEN_CONTRACT,
+  BASE_TOKEN_CONTRACT,
+  CURVE_AAVE_POOLER_CONTRACT,
+  CURVE_AAVE_STAKER_CONTRACT,
+  LP_SFT_CONTRACT,
+  UNI_V3_POOL_FACTORY_CONTRACT,
+  UNI_V3_POOLER_CONTRACT,
+  UNI_V3_STAKER_CONTRACT,
+  UNI_V3_SWAPPER_CONTRACT,
+};

--- a/src/contracts/depends.ts
+++ b/src/contracts/depends.ts
@@ -14,6 +14,7 @@ import gaugeControllerArtifact from "../../contracts/bytecode/curve-dao/GaugeCon
 import liquidityGaugeArtifact from "../../contracts/bytecode/curve-dao/LiquidityGauge.json";
 import minterArtifact from "../../contracts/bytecode/curve-dao/Minter.json";
 import votingEscrowArtifact from "../../contracts/bytecode/curve-dao/VotingEscrow.json";
+import erc20Abi from "../abi/@openzeppelin/contracts/token/ERC20/IERC20.sol/IERC20.json";
 import aavePoolAbi from "../abi/contracts/depends/aave-v2/protocol/lendingpool/LendingPool.sol/LendingPool.json";
 import aTokenAbi from "../abi/contracts/depends/aave-v2/protocol/tokenization/AToken.sol/AToken.json";
 import uniswapV3FactoryAbi from "../abi/contracts/depends/uniswap-v3-core/UniswapV3Factory.sol/UniswapV3Factory.json";
@@ -70,6 +71,7 @@ export {
   liquidityGaugeArtifact,
   minterArtifact,
   votingEscrowArtifact,
+  erc20Abi,
   aavePoolAbi,
   aTokenAbi,
   uniswapV3FactoryAbi,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -22,6 +22,7 @@ interface AddressBook {
   adaiTokenProxy?: string;
   adaiVariableDebtToken?: string;
   adaiVariableDebtTokenProxy?: string;
+  assetToken?: string;
   ausdcStableDebtToken?: string;
   ausdcStableDebtTokenProxy?: string;
   ausdcToken?: string;
@@ -34,6 +35,7 @@ interface AddressBook {
   ausdtTokenProxy?: string;
   ausdtVariableDebtToken?: string;
   ausdtVariableDebtTokenProxy?: string;
+  baseToken?: string;
   crvController?: string;
   crvMinter?: string;
   crvToken?: string;
@@ -41,13 +43,19 @@ interface AddressBook {
   curveAaveGauge?: string;
   curveAaveLpToken?: string;
   curveAavePool?: string;
+  curveAavePooler?: string;
+  curveAaveStaker?: string;
   daiToken?: string;
+  lpSft?: string;
   uniswapV3Factory?: string;
   uniswapV3NftDescriptor?: string;
   uniswapV3NftManager?: string;
   uniswapV3Pool?: string;
   uniswapV3Staker?: string;
+  uniV3Pooler?: string;
   uniV3PoolFactory?: string;
+  uniV3Staker?: string;
+  uniV3Swapper?: string;
   usdcToken?: string;
   usdtToken?: string;
   wrappedNative?: string;
@@ -57,17 +65,26 @@ interface AddressBook {
 interface ContractLibrary {
   adaiTokenContract: ethers.Contract;
   adaiTokenProxyContract: ethers.Contract;
+  assetTokenContract: ethers.Contract;
   ausdcTokenContract: ethers.Contract;
   ausdcTokenProxyContract: ethers.Contract;
   ausdtTokenContract: ethers.Contract;
   ausdtTokenProxyContract: ethers.Contract;
+  baseTokenContract: ethers.Contract;
   curveAaveGaugeContract: ethers.Contract;
   curveAaveLpTokenContract: ethers.Contract;
   curveAavePoolContract: ethers.Contract;
+  curveAavePoolerContract: ethers.Contract;
+  curveAaveStakerContract: ethers.Contract;
   daiTokenContract: ethers.Contract;
+  lpSftContract: ethers.Contract;
   uniswapV3FactoryContract: ethers.Contract;
   uniswapV3NftManagerContract: ethers.Contract;
+  uniswapV3PoolContract: ethers.Contract;
   uniswapV3StakerContract: ethers.Contract;
+  uniV3PoolerContract: ethers.Contract;
+  uniV3StakerContract: ethers.Contract;
+  uniV3SwapperContract: ethers.Contract;
   usdcTokenContract: ethers.Contract;
   usdtTokenContract: ethers.Contract;
 }

--- a/src/utils/fixedMath.ts
+++ b/src/utils/fixedMath.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/contracts
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+import bn from "bignumber.js";
+import { ethers } from "ethers";
+
+// Setup bn.js
+bn.config({ EXPONENTIAL_AT: 999999, DECIMAL_PLACES: 40 });
+
+function decodeX128Int(x128Int: ethers.BigNumber): ethers.BigNumber {
+  return ethers.BigNumber.from(x128Int).div(ethers.BigNumber.from(2).pow(128));
+}
+
+// Returns the sqrt price as a 64x96
+function encodePriceSqrt(
+  reserve1: ethers.BigNumber,
+  reserve0: ethers.BigNumber
+): ethers.BigNumber {
+  return ethers.BigNumber.from(
+    new bn(reserve1.toString())
+      .div(reserve0.toString())
+      .sqrt()
+      .multipliedBy(new bn(2).pow(96))
+      .integerValue(3)
+      .toString()
+  );
+}
+
+export { decodeX128Int, encodePriceSqrt };

--- a/src/utils/lpNftUtils.ts
+++ b/src/utils/lpNftUtils.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/contracts
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+//
+// LP NFT utility functions
+//
+
+function extractJSONFromURI(uri: string): {
+  name: string;
+  description: string;
+  image: string;
+} {
+  const encodedJSON = uri.substr("data:application/json;base64,".length);
+  const decodedJSON = Buffer.from(encodedJSON, "base64").toString("utf8");
+  return JSON.parse(decodedJSON);
+}
+
+export { extractJSONFromURI };

--- a/src/utils/setupFixture.ts
+++ b/src/utils/setupFixture.ts
@@ -13,12 +13,23 @@ import { DeploymentsExtension } from "hardhat-deploy/types";
 
 import { getAddressBook } from "../addressBook";
 import {
+  assetTokenAbi,
+  baseTokenAbi,
+  curveAavePoolerAbi,
+  curveAaveStakerAbi,
+  lpSftAbi,
+  uniV3PoolerAbi,
+  uniV3StakerAbi,
+  uniV3SwapperAbi,
+} from "../contracts/dapp";
+import {
   aTokenAbi,
   curveTokenV3Artifact,
   liquidityGaugeArtifact,
   stableSwapAaveArtifact,
   uniswapV3FactoryAbi,
   uniswapV3NftManagerAbi,
+  uniswapV3PoolAbi,
   uniswapV3StakerAbi,
 } from "../contracts/depends";
 import { daiTokenAbi, usdcTokenAbi, usdtTokenAbi } from "../contracts/testing";
@@ -57,6 +68,11 @@ async function setupFixture({
     aTokenAbi,
     beneficiary
   );
+  const assetTokenContract = new ethers.Contract(
+    addressBook.assetToken,
+    assetTokenAbi,
+    beneficiary
+  );
   const ausdcTokenContract = new ethers.Contract(
     addressBook.ausdcToken,
     aTokenAbi,
@@ -75,6 +91,11 @@ async function setupFixture({
   const ausdtTokenProxyContract = new ethers.Contract(
     addressBook.ausdtTokenProxy,
     aTokenAbi,
+    beneficiary
+  );
+  const baseTokenContract = new ethers.Contract(
+    addressBook.baseToken,
+    baseTokenAbi,
     beneficiary
   );
   const daiTokenContract = new ethers.Contract(
@@ -97,6 +118,21 @@ async function setupFixture({
     JSON.stringify(stableSwapAaveArtifact.abi), // Work around TypeScript problem
     beneficiary
   );
+  const curveAavePoolerContract = new ethers.Contract(
+    addressBook.curveAavePooler,
+    curveAavePoolerAbi,
+    beneficiary
+  );
+  const curveAaveStakerContract = new ethers.Contract(
+    addressBook.curveAaveStaker,
+    curveAaveStakerAbi,
+    beneficiary
+  );
+  const lpSftContract = new ethers.Contract(
+    addressBook.lpSft,
+    lpSftAbi,
+    beneficiary
+  );
   const uniswapV3FactoryContract = new ethers.Contract(
     addressBook.uniswapV3Factory,
     uniswapV3FactoryAbi,
@@ -107,9 +143,29 @@ async function setupFixture({
     uniswapV3NftManagerAbi,
     beneficiary
   );
+  const uniswapV3PoolContract = new ethers.Contract(
+    addressBook.uniswapV3Pool,
+    uniswapV3PoolAbi,
+    beneficiary
+  );
   const uniswapV3StakerContract = new ethers.Contract(
     addressBook.uniswapV3Staker,
     uniswapV3StakerAbi,
+    beneficiary
+  );
+  const uniV3PoolerContract = new ethers.Contract(
+    addressBook.uniV3Pooler,
+    uniV3PoolerAbi,
+    beneficiary
+  );
+  const uniV3StakerContract = new ethers.Contract(
+    addressBook.uniV3Staker,
+    uniV3StakerAbi,
+    beneficiary
+  );
+  const uniV3SwapperContract = new ethers.Contract(
+    addressBook.uniV3Swapper,
+    uniV3SwapperAbi,
     beneficiary
   );
   const usdcTokenContract = new ethers.Contract(
@@ -126,17 +182,26 @@ async function setupFixture({
   return {
     adaiTokenContract,
     adaiTokenProxyContract,
+    assetTokenContract,
     ausdcTokenContract,
     ausdcTokenProxyContract,
     ausdtTokenContract,
     ausdtTokenProxyContract,
+    baseTokenContract,
     daiTokenContract,
     curveAaveGaugeContract,
     curveAaveLpTokenContract,
     curveAavePoolContract,
+    curveAavePoolerContract,
+    curveAaveStakerContract,
+    lpSftContract,
     uniswapV3FactoryContract,
     uniswapV3NftManagerContract,
+    uniswapV3PoolContract,
     uniswapV3StakerContract,
+    uniV3PoolerContract,
+    uniV3StakerContract,
+    uniV3SwapperContract,
     usdcTokenContract,
     usdtTokenContract,
   };

--- a/src/utils/tickMath.ts
+++ b/src/utils/tickMath.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/contracts
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+function getMinTick(tickSpacing: number): number {
+  return Math.ceil(-887272 / tickSpacing) * tickSpacing;
+}
+
+function getMaxTick(tickSpacing: number): number {
+  return Math.floor(887272 / tickSpacing) * tickSpacing;
+}
+
+export { getMinTick, getMaxTick };

--- a/test/test-curve.ts
+++ b/test/test-curve.ts
@@ -35,8 +35,8 @@ describe("Curve Aave pool", function () {
   const DAI_BALANCE = ethers.utils.parseUnits("1000", 18);
   const USDC_BALANCE = ethers.utils.parseUnits("1000", 6);
   const USDT_BALANCE = ethers.utils.parseUnits("1000", 6);
-  const CURVE_AAVE_LP_BALANCE = ethers.BigNumber.from("2999963038010893115846"); // About 3,000 tokens
-  const DAI_FINAL_BALANCE = ethers.BigNumber.from("2999255314545236860053"); // About 2,999 DAI
+  const CURVE_AAVE_LP_BALANCE = ethers.BigNumber.from("2999963037994045801166"); // About 3,000 tokens
+  const DAI_FINAL_BALANCE = ethers.BigNumber.from("2999255314468488916363"); // About 2,999 DAI
 
   //////////////////////////////////////////////////////////////////////////////
   // Mocha setup

--- a/test/test-liquidity-math.ts
+++ b/test/test-liquidity-math.ts
@@ -1,0 +1,602 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/contracts
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import chai from "chai";
+import { solidity } from "ethereum-waffle";
+import { ethers } from "ethers";
+import * as hardhat from "hardhat";
+
+import { uniV3StakerAbi } from "../src/contracts/dapp";
+import { ContractLibrary } from "../src/interfaces";
+import { setupFixture } from "../src/utils/setupFixture";
+
+// Setup Mocha
+chai.use(solidity);
+
+// Setup Hardhat
+const setupTest = hardhat.deployments.createFixture(setupFixture);
+
+//
+// Test cases
+//
+
+describe("Liquidity math", () => {
+  let deployer: SignerWithAddress | undefined;
+  let beneficiaryAddress: string;
+  let contracts: ContractLibrary;
+  let nftTokenId: number | undefined; // Set when first LP NFT is minted
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Test parameters
+  //////////////////////////////////////////////////////////////////////////////
+
+  //
+  // Before depositing, we check the deployer's liquidity position and token
+  // balances
+  //
+
+  // Initial USDC held by the deployer
+  const INITIAL_DEPLOYER_USDC = ethers.BigNumber.from(0);
+
+  // Initial base tokens held by the deployer (includes dust from first mint)
+  const INITIAL_DEPLOYER_BASE_TOKENS = ethers.BigNumber.from(
+    "8999000000068009583402"
+  ); // About 8,999 base tokens
+
+  // Initial asset tokens held by the deployer
+  const INITIAL_DEPLOYER_ASSET_TOKENS = ethers.BigNumber.from(0);
+
+  // Initial liquidity position of the deployer
+  const INITIAL_DEPLOYER_LIQUIDITY = ethers.BigNumber.from(
+    "1000010502043492201"
+  ); // About 1 liquidity unit
+
+  // Initial base token reserves
+  const INITIAL_BASE_RESERVES = ethers.BigNumber.from("999999931990416598"); // About 1 base token
+
+  // Initial asset token reserves
+  const INITIAL_ASSET_RESERVES = ethers.BigNumber.from("1000021072895273801"); // About 1 asset token
+
+  //
+  // Before minting, we check the price using 0.001 USDC to minimize slippage
+  //
+
+  // Amount of USDC used to check the price (small to minimize slippage)
+  const USDC_PRICE_CHECK_AMOUNT = ethers.utils.parseUnits("0.001", 6); // 0.001 USDC
+
+  // Initial price of the base token
+  const INITIAL_BASE_PRICE = ethers.BigNumber.from("988950661395079"); // About 0.989 base tokens per USDC
+
+  //
+  // We mint an LP NFT and deposit 1 USDC
+  //
+  // Note that this incurs heavy slippage, as the pool initially has only one
+  // of each token in its reserve.
+  //
+
+  // We start with 1 USDC
+  const INITIAL_USDC_BALANCE = ethers.utils.parseUnits("1", 6); // 1 USDC
+
+  // We stake the USDC in the Curve Aave pool and pay a 0.3% fee
+  const CURVE_AAVE_LP_AMOUNT = ethers.BigNumber.from("999721087829635796"); // About 1 LP token
+
+  // Curve Gauge shares are issued 1:1 with LP tokens
+  const CURVE_AAVE_GAUGE_SHARES = CURVE_AAVE_LP_AMOUNT; // About 1 gauge share
+
+  // We swap asset tokens into base tokens
+  const BASE_TOKENS_BOUGHT = ethers.BigNumber.from("291844915735727073"); // About 0.292 base tokens
+  const ASSET_TOKENS_SPENT = ethers.BigNumber.from("416291700753402559"); // About 0.416 asset tokens
+
+  // We swap asset token dust into base tokens
+  const BASE_DUST_BOUGHT = ethers.BigNumber.from("721353409870846"); // About 0.0007 base tokens
+  const ASSET_DUST_SPENT = ethers.BigNumber.from("1454047980508158"); // About 0.001 asset tokens
+
+  // Share of the tokens in the LP NFT
+  const BASE_TOKEN_SHARE = BASE_TOKENS_BOUGHT; // About 0.292 base tokens
+  const ASSET_TOKEN_SHARE = ethers.BigNumber.from("581975339095725079"); // About 0.582 asset tokens
+
+  // Amount of Uniswap V3 liquidity
+  const LIQUIDITY_AMOUNT = ethers.BigNumber.from("412124427568499117"); // About 0.412 liquidity units
+
+  //
+  // Check the price and reserves after minting the LP NFT
+  //
+  // The resulting price is expected to be cut in half, as the pool now has
+  // 1 base token and 2 asset tokens in its reserves.
+  //
+
+  // Resulting price of base token
+  const RESULTING_BASE_PRICE = ethers.BigNumber.from("495471740396258"); // About 0.495 base tokens per USDC
+
+  // Resulting base token reserves
+  const RESULTING_BASE_RESERVES = ethers.BigNumber.from("999278578580545752"); // About 1 base token
+
+  // Resulting asset token reserves
+  const RESULTING_ASSET_RESERVES = ethers.BigNumber.from("1999742160724909597"); // About 2 USDC
+
+  //
+  // Finally, we unstake the LP NFT for USDC
+  //
+
+  // Tokens collected from the LP NFT
+  const BASE_TOKENS_COLLECTED = ethers.BigNumber.from("291634392396290031"); // About 0.292 base tokens
+  const ASSET_TOKENS_COLLECTED = ethers.BigNumber.from("582399695634932497"); // About 0.582 asset tokens
+
+  // Base tokens are sold for asset tokens
+  const ASSET_TOKENS_BOUGHT = ethers.BigNumber.from("409497122600816316"); // About 0.409 asset tokens
+
+  // Asset tokens are unstaked from the Curve Aave gauge
+  const CURVE_AAVE_GAUGE_UNSTAKED = ethers.BigNumber.from("991896818235748813"); // About 0.992 gauge shares
+
+  // LP tokens are returned to the Curve Aave pool
+  const CURVE_AAVE_LP_UNSTAKED = CURVE_AAVE_GAUGE_UNSTAKED; // About 0.992 LP tokens
+
+  // Withdrawn USDC from the Curve Aave pool
+  const USDC_RETURNED = ethers.BigNumber.from("991767"); // About 0.992 USDC
+
+  //
+  // Check the price and reserves after minting the LP NFT
+  //
+  // The resulting price is expected to be cut in half, as the pool now has
+  // 1 base token and 2 asset tokens in its reserves.
+  //
+
+  // Final price of base token
+  const FINAL_BASE_PRICE = ethers.BigNumber.from("981772273085180"); // About 0.982 base tokens per USDC
+
+  // Final base token reserves
+  const FINAL_BASE_RESERVES = ethers.BigNumber.from("999278578580545752"); // About 0.999 base tokens
+
+  // Final asset token reserves
+  const FINAL_ASSET_RESERVES = ethers.BigNumber.from("1007845342489160784"); // About 1.008 asset tokens
+
+  // Remaining token dust
+  const BASE_TOKEN_DUST = ethers.BigNumber.from("721353409870846"); // About 0.0007 base tokens
+  const ASSET_TOKEN_DUST = ethers.BigNumber.from(0);
+
+  // Final USDC balance
+  const FINAL_USDC_BALANCE = ethers.BigNumber.from("992767"); // About 0.993 USDC
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Mocha setup
+  //////////////////////////////////////////////////////////////////////////////
+
+  before(async function () {
+    this.timeout(60 * 1000);
+
+    // Get the Signers
+    [deployer] = await hardhat.ethers.getSigners();
+
+    // Get the beneficiary wallet
+    const namedAccounts: {
+      [name: string]: string;
+    } = await hardhat.getNamedAccounts();
+    beneficiaryAddress = namedAccounts.beneficiary;
+
+    // A single fixture is used for the test suite
+    contracts = await setupTest();
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Setup: Obtain tokens
+  //////////////////////////////////////////////////////////////////////////////
+
+  it("should obtain USDC", async function () {
+    this.timeout(60 * 1000);
+
+    const { usdcTokenContract } = contracts;
+
+    // Mint USDC
+    const tx: Promise<ethers.ContractTransaction> = usdcTokenContract.mint(
+      beneficiaryAddress,
+      INITIAL_USDC_BALANCE.add(USDC_PRICE_CHECK_AMOUNT)
+    );
+    await (await tx).wait();
+
+    const usdcBalance = await usdcTokenContract.balanceOf(beneficiaryAddress);
+    chai
+      .expect(usdcBalance)
+      .to.equal(INITIAL_USDC_BALANCE.add(USDC_PRICE_CHECK_AMOUNT));
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Test deployer's balances
+  //////////////////////////////////////////////////////////////////////////////
+
+  it("should check the deployer's balances", async function () {
+    this.timeout(60 * 1000);
+
+    const {
+      assetTokenContract,
+      baseTokenContract,
+      uniswapV3NftManagerContract,
+      uniswapV3PoolContract,
+      usdcTokenContract,
+    } = contracts;
+
+    // Check token balances
+    const usdcBalance = await usdcTokenContract.balanceOf(deployer.address);
+    chai.expect(usdcBalance).to.equal(INITIAL_DEPLOYER_USDC);
+
+    const baseTokenBalance = await baseTokenContract.balanceOf(
+      deployer.address
+    );
+    chai.expect(baseTokenBalance).to.equal(INITIAL_DEPLOYER_BASE_TOKENS);
+
+    const assetTokenBalance = await assetTokenContract.balanceOf(
+      deployer.address
+    );
+    chai.expect(assetTokenBalance).to.equal(INITIAL_DEPLOYER_ASSET_TOKENS);
+
+    // Get the deployer's LP NFT token ID
+    const deployerLpNftTokenId =
+      await uniswapV3NftManagerContract.tokenOfOwnerByIndex(
+        deployer.address,
+        0
+      );
+
+    // Uniswap V3 LP NFT token IDs start at 1
+    chai.expect(deployerLpNftTokenId).to.equal(1);
+
+    // Get the deployer's liquidity position
+    const [, , , , , , , liquidity, , , ,] =
+      await uniswapV3NftManagerContract.positions(deployerLpNftTokenId);
+
+    chai.expect(liquidity).to.equal(INITIAL_DEPLOYER_LIQUIDITY);
+
+    // Get reserves of the Uniswap V3 pool
+    const baseReserves = await baseTokenContract.balanceOf(
+      uniswapV3PoolContract.address
+    );
+    const assetReserves = await assetTokenContract.balanceOf(
+      uniswapV3PoolContract.address
+    );
+
+    chai.expect(baseReserves).to.equal(INITIAL_BASE_RESERVES);
+    chai.expect(assetReserves).to.equal(INITIAL_ASSET_RESERVES);
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Test Uniswap V3 LP NFTs
+  //////////////////////////////////////////////////////////////////////////////
+
+  it("should approve UniV3 swapper spending USDC", async function () {
+    this.timeout(60 * 1000);
+
+    const { uniV3SwapperContract, usdcTokenContract } = contracts;
+
+    const tx: Promise<ethers.ContractTransaction> = usdcTokenContract.approve(
+      uniV3SwapperContract.address, // spender
+      USDC_PRICE_CHECK_AMOUNT // value
+    );
+
+    await chai.expect(tx).to.emit(usdcTokenContract, "Approval").withArgs(
+      beneficiaryAddress, // owner
+      uniV3SwapperContract.address, // spender
+      USDC_PRICE_CHECK_AMOUNT // value
+    );
+  });
+
+  it("should check initial base token price", async function () {
+    this.timeout(60 * 1000);
+
+    const { uniV3SwapperContract } = contracts;
+
+    // TODO: We need a method that doesn't require a prior allowance
+    const baseTokenPrice =
+      await uniV3SwapperContract.callStatic.buyTokensOneStable(
+        1, // stableIndex
+        USDC_PRICE_CHECK_AMOUNT // stableAmount
+      );
+
+    chai.expect(baseTokenPrice).to.equal(INITIAL_BASE_PRICE);
+  });
+
+  it("should approve UniV3 staker spending USDC", async function () {
+    this.timeout(60 * 1000);
+
+    const { uniV3StakerContract, usdcTokenContract } = contracts;
+
+    const tx: Promise<ethers.ContractTransaction> = usdcTokenContract.approve(
+      uniV3StakerContract.address, // spender
+      INITIAL_USDC_BALANCE // value
+    );
+
+    await chai.expect(tx).to.emit(usdcTokenContract, "Approval").withArgs(
+      beneficiaryAddress, // owner
+      uniV3StakerContract.address, // spender
+      INITIAL_USDC_BALANCE // value
+    );
+  });
+
+  it("should stake an LP NFT with USDC", async function () {
+    this.timeout(60 * 1000);
+
+    const {
+      curveAavePoolerContract,
+      curveAaveStakerContract,
+      uniswapV3NftManagerContract,
+      uniV3PoolerContract,
+      uniV3StakerContract,
+      uniV3SwapperContract,
+    } = contracts;
+
+    // Deposit tokens and stake the NFT
+    const tx: Promise<ethers.ContractTransaction> =
+      uniV3StakerContract.stakeNFTWithStables(
+        [0, INITIAL_USDC_BALANCE, 0], // stableAmounts
+        beneficiaryAddress // recipient
+      );
+
+    // Get NFT token ID
+    const receipt: ethers.ContractReceipt = await (await tx).wait();
+    const iface: ethers.utils.Interface = new ethers.utils.Interface(
+      uniV3StakerAbi
+    );
+    const log = receipt.logs.find((log) => {
+      try {
+        return iface.parseLog(log).name === "NFTStaked";
+      } catch (e) {
+        return false;
+      }
+    });
+    const logDescription: ethers.utils.LogDescription = iface.parseLog(log);
+    nftTokenId = logDescription.args[3].toNumber();
+    console.log("    LP NFT token ID:", nftTokenId);
+
+    //
+    // Check routing events
+    //
+
+    await chai
+      .expect(tx)
+      .to.emit(curveAavePoolerContract, "LiquidityAdded")
+      .withArgs(
+        curveAaveStakerContract.address, // sender
+        curveAaveStakerContract.address, // recipient
+        [0, INITIAL_USDC_BALANCE, 0], // stableAmounts
+        CURVE_AAVE_LP_AMOUNT // lpTokenAmount
+      );
+    await chai
+      .expect(tx)
+      .to.emit(curveAaveStakerContract, "GaugeStaked")
+      .withArgs(
+        uniV3PoolerContract.address, // sender
+        uniV3PoolerContract.address, // recipient
+        [0, INITIAL_USDC_BALANCE, 0], // stableAmounts
+        CURVE_AAVE_GAUGE_SHARES // gaugeShares
+      );
+    await chai
+      .expect(tx)
+      .to.emit(uniV3SwapperContract, "TokensBought")
+      .withArgs(
+        uniV3PoolerContract.address, // sender
+        uniV3PoolerContract.address, // recipient
+        [0, 0, 0], // stableAmounts
+        ASSET_TOKENS_SPENT, // assetTokenAmount
+        BASE_TOKENS_BOUGHT // baseTokenReturned
+      );
+    await chai.expect(tx).to.emit(uniV3PoolerContract, "NFTMinted").withArgs(
+      uniV3StakerContract.address, // sender
+      uniV3StakerContract.address, // recipient
+      uniswapV3NftManagerContract.address, // nftAddress
+      nftTokenId, // nftTokenId
+      [0, INITIAL_USDC_BALANCE, 0], // stableAmounts
+      0, // baseTokenAmount
+      BASE_TOKEN_SHARE, // baseTokenShare
+      ASSET_TOKEN_SHARE, // assetTokenShare
+      LIQUIDITY_AMOUNT // liquidityAmount
+    );
+    await chai.expect(tx).to.emit(uniV3StakerContract, "NFTStaked").withArgs(
+      beneficiaryAddress, // sender
+      beneficiaryAddress, // recipient
+      uniswapV3NftManagerContract.address, // nftAddress
+      nftTokenId, // nftTokenId
+      [0, INITIAL_USDC_BALANCE, 0], // stableAmounts
+      0 // baseTokenAmount
+    );
+    await chai
+      .expect(tx)
+      .to.emit(uniV3SwapperContract, "TokensBought")
+      .withArgs(
+        uniV3PoolerContract.address, // sender
+        uniV3PoolerContract.address, // recipient
+        [0, 0, 0], // stableAmounts
+        ASSET_DUST_SPENT, // assetTokenAmount
+        BASE_DUST_BOUGHT // baseTokenReturned
+      );
+  });
+
+  it("should check resulting base token price", async function () {
+    this.timeout(60 * 1000);
+
+    const {
+      assetTokenContract,
+      baseTokenContract,
+      uniswapV3PoolContract,
+      uniV3PoolerContract,
+      uniV3SwapperContract,
+      usdcTokenContract,
+    } = contracts;
+
+    // Get base token price
+    const baseTokenPrice =
+      await uniV3SwapperContract.callStatic.buyTokensOneStable(
+        1,
+        USDC_PRICE_CHECK_AMOUNT
+      );
+
+    chai.expect(baseTokenPrice).to.equal(RESULTING_BASE_PRICE);
+
+    // Get reserves of the Uniswap V3 pool
+    const baseReserves = await baseTokenContract.balanceOf(
+      uniswapV3PoolContract.address
+    );
+    const assetReserves = await assetTokenContract.balanceOf(
+      uniswapV3PoolContract.address
+    );
+
+    chai.expect(baseReserves).to.equal(RESULTING_BASE_RESERVES);
+    chai.expect(assetReserves).to.equal(RESULTING_ASSET_RESERVES);
+
+    // Check balances of the staker
+    const poolerBaseBalance = await baseTokenContract.balanceOf(
+      uniV3PoolerContract.address
+    );
+    const poolerAssetBalance = await assetTokenContract.balanceOf(
+      uniV3PoolerContract.address
+    );
+
+    chai.expect(poolerBaseBalance).to.equal(0);
+    chai.expect(poolerAssetBalance).to.equal(0);
+
+    // Check balances of the beneficiary
+    const usdcTokenBalance = await usdcTokenContract.balanceOf(
+      beneficiaryAddress
+    );
+
+    chai.expect(usdcTokenBalance).to.equal(USDC_PRICE_CHECK_AMOUNT);
+  });
+
+  it("should unstake the LP NFT", async function () {
+    this.timeout(60 * 1000);
+
+    const {
+      curveAavePoolerContract,
+      curveAaveStakerContract,
+      uniswapV3NftManagerContract,
+      uniV3PoolerContract,
+      uniV3StakerContract,
+      uniV3SwapperContract,
+    } = contracts;
+
+    // Unstake the NFT
+    const tx: Promise<ethers.ContractTransaction> =
+      uniV3StakerContract.exitOneStable(
+        nftTokenId, // nftTokenId
+        1 // stableIndex
+      );
+
+    // Get reward amount
+    const receipt: ethers.ContractReceipt = await (await tx).wait();
+    const iface: ethers.utils.Interface = new ethers.utils.Interface(
+      uniV3StakerAbi
+    );
+    const log = receipt.logs.find((log) => {
+      try {
+        return iface.parseLog(log).name === "NFTUnstaked";
+      } catch (e) {
+        return false;
+      }
+    });
+    const logDescription: ethers.utils.LogDescription = iface.parseLog(log);
+    const rewardClaimed: ethers.BigNumber = logDescription.args[4];
+
+    //
+    // Check routing events
+    //
+
+    await chai.expect(tx).to.emit(uniV3StakerContract, "NFTUnstaked").withArgs(
+      beneficiaryAddress, // sender
+      beneficiaryAddress, // recipient
+      uniswapV3NftManagerContract.address, // nftAddress
+      nftTokenId, // nftTokenId
+      rewardClaimed, // rewardClaimed
+      1, // stableIndex
+      USDC_RETURNED // stablesReturned
+    );
+    await chai.expect(tx).to.emit(uniV3PoolerContract, "NFTCollected").withArgs(
+      uniV3StakerContract.address, // sender
+      uniV3StakerContract.address, // recipient
+      uniswapV3NftManagerContract.address, // nftAddress
+      nftTokenId, // nftTokenId
+      LIQUIDITY_AMOUNT, // liquidityAmount
+      BASE_TOKENS_COLLECTED, // baseTokensCollected
+      ASSET_TOKENS_COLLECTED, // assetTokensCollected
+      1, // stableIndex (USDC)
+      USDC_RETURNED // stablesReturned
+    );
+    await chai
+      .expect(tx)
+      .to.emit(uniV3SwapperContract, "TokensSoldForAsset")
+      .withArgs(
+        uniV3PoolerContract.address, // sender
+        uniV3PoolerContract.address, // recipient
+        BASE_TOKENS_COLLECTED, // baseTokenSpent
+        ASSET_TOKENS_BOUGHT // assetTokensReturned
+      );
+    await chai
+      .expect(tx)
+      .to.emit(curveAaveStakerContract, "GaugeUnstakedOneStable")
+      .withArgs(
+        uniV3PoolerContract.address, // sender
+        uniV3PoolerContract.address, // recipient
+        CURVE_AAVE_GAUGE_UNSTAKED, // gaugeShares
+        1, // stableIndex (USDC)
+        USDC_RETURNED // stablesReturned
+      );
+    await chai
+      .expect(tx)
+      .to.emit(curveAavePoolerContract, "LiquidityRemovedOneStable")
+      .withArgs(
+        curveAaveStakerContract.address, // sender
+        curveAaveStakerContract.address, // recipient
+        CURVE_AAVE_LP_UNSTAKED, // lpTokenAmount
+        1, // stableIndex (USDC)
+        USDC_RETURNED // stablesReturned
+      );
+  });
+
+  it("should check final base token price", async function () {
+    this.timeout(60 * 1000);
+
+    const {
+      assetTokenContract,
+      baseTokenContract,
+      uniswapV3PoolContract,
+      uniV3SwapperContract,
+      usdcTokenContract,
+    } = contracts;
+
+    // Get base token price
+    const baseTokenPrice =
+      await uniV3SwapperContract.callStatic.buyTokensOneStable(
+        1,
+        USDC_PRICE_CHECK_AMOUNT
+      );
+
+    chai.expect(baseTokenPrice).to.equal(FINAL_BASE_PRICE);
+
+    // Get reserves of the Uniswap V3 pool
+    const baseReserves = await baseTokenContract.balanceOf(
+      uniswapV3PoolContract.address
+    );
+    const assetReserves = await assetTokenContract.balanceOf(
+      uniswapV3PoolContract.address
+    );
+
+    chai.expect(baseReserves).to.equal(FINAL_BASE_RESERVES);
+    chai.expect(assetReserves).to.equal(FINAL_ASSET_RESERVES);
+
+    // Check token balanceS of the beneficiary
+    const baseTokenBalance = await baseTokenContract.balanceOf(
+      beneficiaryAddress
+    );
+    const assetTokenBalance = await assetTokenContract.balanceOf(
+      beneficiaryAddress
+    );
+    const usdcTokenBalance = await usdcTokenContract.balanceOf(
+      beneficiaryAddress
+    );
+
+    chai.expect(baseTokenBalance).to.equal(BASE_TOKEN_DUST);
+    chai.expect(assetTokenBalance).to.equal(ASSET_TOKEN_DUST);
+    chai.expect(usdcTokenBalance).to.equal(FINAL_USDC_BALANCE);
+  });
+});

--- a/test/test-lp-sft.ts
+++ b/test/test-lp-sft.ts
@@ -1,0 +1,741 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/contracts
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import chai from "chai";
+import { solidity } from "ethereum-waffle";
+import { ethers } from "ethers";
+import * as hardhat from "hardhat";
+
+import { uniV3StakerAbi } from "../src/contracts/dapp";
+import { ContractLibrary } from "../src/interfaces";
+import { setupFixture } from "../src/utils/setupFixture";
+
+// Setup Mocha
+chai.use(solidity);
+
+// Setup Hardhat
+const setupTest = hardhat.deployments.createFixture(setupFixture);
+
+//
+// Test cases
+//
+
+describe("LP SFTs", () => {
+  let deployer: SignerWithAddress;
+  let beneficiaryAddress: string;
+  let contracts: ContractLibrary;
+  let nftTokenId1: ethers.BigNumber | undefined; // Set when first LP NFT is minted
+  let nftTokenId2: ethers.BigNumber | undefined; // Set when second LP NFT is minted
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Test parameters
+  //////////////////////////////////////////////////////////////////////////////
+
+  // The ID of the deployer's LP NFT. Uniswap V3 starts minting at ID 1
+  const DEPLOYER_NFT_TOKEN_ID = 1;
+
+  // We start with 2 USDC
+  const INITIAL_USDC_BALANCE = ethers.utils.parseUnits("2", 6); // 2 USDC
+
+  // Base token dust after minting LP NFTs
+  const BASE_TOKEN_DUST = ethers.BigNumber.from("899748346464365"); // About 0.0009 base tokens
+
+  // Balance after unstaking first LP NFT
+  const INTERMEDIATE_USDC_BALANCE = ethers.BigNumber.from("1253098"); // About 1.253 USDC
+
+  // We end with about 1.3 cents less (0.67% loss)
+  const FINAL_USDC_BALANCE = ethers.BigNumber.from("1986669"); // About 1.987 USDC
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Mocha setup
+  //////////////////////////////////////////////////////////////////////////////
+
+  before(async function () {
+    this.timeout(60 * 1000);
+
+    // Get the Signers
+    [deployer] = await hardhat.ethers.getSigners();
+
+    // Get the beneficiary wallet
+    const namedAccounts: {
+      [name: string]: string;
+    } = await hardhat.getNamedAccounts();
+    beneficiaryAddress = namedAccounts.beneficiary;
+
+    // A single fixture is used for the test suite
+    contracts = await setupTest();
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Setup: Obtain tokens
+  //////////////////////////////////////////////////////////////////////////////
+
+  it("should obtain USDC", async function () {
+    this.timeout(60 * 1000);
+
+    const { usdcTokenContract } = contracts;
+
+    // Mint USDC
+    const tx: Promise<ethers.ContractTransaction> = usdcTokenContract.mint(
+      beneficiaryAddress,
+      INITIAL_USDC_BALANCE
+    );
+    await (await tx).wait();
+
+    const usdcBalance = await usdcTokenContract.balanceOf(beneficiaryAddress);
+    chai.expect(usdcBalance).to.equal(INITIAL_USDC_BALANCE);
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Test LP SFTs
+  //////////////////////////////////////////////////////////////////////////////
+
+  it("should approve UniV3 staker spending USDC", async function () {
+    this.timeout(60 * 1000);
+
+    const { uniV3StakerContract, usdcTokenContract } = contracts;
+
+    const tx: Promise<ethers.ContractTransaction> = usdcTokenContract.approve(
+      uniV3StakerContract.address, // spender
+      INITIAL_USDC_BALANCE // value
+    );
+
+    await chai.expect(tx).to.emit(usdcTokenContract, "Approval").withArgs(
+      beneficiaryAddress, // owner
+      uniV3StakerContract.address, // spender
+      INITIAL_USDC_BALANCE // value
+    );
+  });
+
+  it("should stake an LP NFT with USDC", async function () {
+    this.timeout(60 * 1000);
+
+    const {
+      lpSftContract,
+      uniswapV3NftManagerContract,
+      uniswapV3StakerContract,
+      uniV3StakerContract,
+    } = contracts;
+
+    // Deposit tokens and stake the NFT with half of the USDC
+    const tx: Promise<ethers.ContractTransaction> =
+      uniV3StakerContract.stakeNFTWithStables(
+        [0, INITIAL_USDC_BALANCE.div(2), 0], // stableAmounts
+        beneficiaryAddress // recipient
+      );
+
+    // Get NFT token ID
+    const receipt: ethers.ContractReceipt = await (await tx).wait();
+    const iface: ethers.utils.Interface = new ethers.utils.Interface(
+      uniV3StakerAbi
+    );
+    const log = receipt.logs.find((log) => {
+      try {
+        return iface.parseLog(log).name === "NFTStaked";
+      } catch (e) {
+        return false;
+      }
+    });
+    const logDescription: ethers.utils.LogDescription = iface.parseLog(log);
+    nftTokenId1 = logDescription.args[3];
+    console.log("    LP NFT token ID:", nftTokenId1.toNumber());
+
+    //
+    // Check LP NFT path
+    //
+
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3NftManagerContract, "Transfer")
+      .withArgs(
+        ethers.constants.AddressZero, // from
+        uniV3StakerContract.address, // to
+        nftTokenId1 // tokenId
+      );
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3NftManagerContract, "Transfer")
+      .withArgs(
+        uniV3StakerContract.address, // from
+        uniswapV3StakerContract.address, // to
+        nftTokenId1 // tokenId
+      );
+
+    //
+    // Check LP SFT path
+    //
+
+    await chai.expect(tx).to.emit(lpSftContract, "TransferSingle").withArgs(
+      uniV3StakerContract.address, // operator
+      ethers.constants.AddressZero, // from
+      beneficiaryAddress, // to
+      nftTokenId1, // id
+      1 // value
+    );
+  });
+
+  it("should check NFT and SFT ownerships after first stake", async function () {
+    this.timeout(60 * 1000);
+
+    const {
+      lpSftContract,
+      uniswapV3NftManagerContract,
+      uniswapV3StakerContract,
+    } = contracts;
+
+    // Check NFT owners
+    const deployerNftOwner = await uniswapV3NftManagerContract.ownerOf(
+      DEPLOYER_NFT_TOKEN_ID
+    );
+    const beneficiaryNft1Owner = await uniswapV3NftManagerContract.ownerOf(
+      nftTokenId1
+    );
+
+    chai.expect(deployerNftOwner).to.equal(deployer.address);
+    chai.expect(beneficiaryNft1Owner).to.equal(uniswapV3StakerContract.address);
+
+    // Check SFT owners
+    const deployerSftOwner = await lpSftContract.ownerOf(DEPLOYER_NFT_TOKEN_ID);
+    const beneficiarySft1Owner = await lpSftContract.ownerOf(nftTokenId1);
+
+    chai.expect(deployerSftOwner).to.equal(ethers.constants.AddressZero);
+    chai.expect(beneficiarySft1Owner).to.equal(beneficiaryAddress);
+
+    // Check SFT token IDs
+    const deployerSftTokenIds = await lpSftContract.getTokenIds(
+      deployer.address
+    );
+    const beneficiarySftTokenIds = await lpSftContract.getTokenIds(
+      beneficiaryAddress
+    );
+
+    chai.expect(deployerSftTokenIds.length).to.equal(0);
+    chai.expect(beneficiarySftTokenIds.length).to.equal(1);
+
+    chai.expect(deployerSftTokenIds).to.deep.equal([]);
+    chai.expect(beneficiarySftTokenIds).to.deep.equal([nftTokenId1]);
+  });
+
+  it("should stake second LP NFT with USDC", async function () {
+    this.timeout(60 * 1000);
+
+    const {
+      lpSftContract,
+      uniswapV3NftManagerContract,
+      uniswapV3StakerContract,
+      uniV3StakerContract,
+    } = contracts;
+
+    // Deposit tokens and stake the NFT with half of the USDC
+    const tx: Promise<ethers.ContractTransaction> =
+      uniV3StakerContract.stakeNFTWithStables(
+        [0, INITIAL_USDC_BALANCE.div(2), 0], // stableAmounts
+        beneficiaryAddress // recipient
+      );
+
+    // Get NFT token ID
+    const receipt: ethers.ContractReceipt = await (await tx).wait();
+    const iface: ethers.utils.Interface = new ethers.utils.Interface(
+      uniV3StakerAbi
+    );
+    const log = receipt.logs.find((log) => {
+      try {
+        return iface.parseLog(log).name === "NFTStaked";
+      } catch (e) {
+        return false;
+      }
+    });
+    const logDescription: ethers.utils.LogDescription = iface.parseLog(log);
+    nftTokenId2 = logDescription.args[3];
+    console.log("    LP NFT token ID:", nftTokenId2.toNumber());
+
+    //
+    // Check LP NFT path
+    //
+
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3NftManagerContract, "Transfer")
+      .withArgs(
+        ethers.constants.AddressZero, // from
+        uniV3StakerContract.address, // to
+        nftTokenId2 // tokenId
+      );
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3NftManagerContract, "Transfer")
+      .withArgs(
+        uniV3StakerContract.address, // from
+        uniswapV3StakerContract.address, // to
+        nftTokenId2 // tokenId
+      );
+
+    //
+    // Check LP SFT path
+    //
+
+    await chai.expect(tx).to.emit(lpSftContract, "TransferSingle").withArgs(
+      uniV3StakerContract.address, // operator
+      ethers.constants.AddressZero, // from
+      beneficiaryAddress, // to
+      nftTokenId2, // id
+      1 // value
+    );
+  });
+
+  it("should check NFT and SFT ownerships after second stake", async function () {
+    this.timeout(60 * 1000);
+
+    const {
+      lpSftContract,
+      uniswapV3NftManagerContract,
+      uniswapV3StakerContract,
+    } = contracts;
+
+    // Check NFT owners
+    const deployerNftOwner = await uniswapV3NftManagerContract.ownerOf(
+      DEPLOYER_NFT_TOKEN_ID
+    );
+    const beneficiaryNft1Owner = await uniswapV3NftManagerContract.ownerOf(
+      nftTokenId1
+    );
+    const beneficiaryNft2Owner = await uniswapV3NftManagerContract.ownerOf(
+      nftTokenId2
+    );
+
+    chai.expect(deployerNftOwner).to.equal(deployer.address);
+    chai.expect(beneficiaryNft1Owner).to.equal(uniswapV3StakerContract.address);
+    chai.expect(beneficiaryNft2Owner).to.equal(uniswapV3StakerContract.address);
+
+    // Check SFT owners
+    const deployerSftOwner = await lpSftContract.ownerOf(DEPLOYER_NFT_TOKEN_ID);
+    const beneficiarySft1Owner = await lpSftContract.ownerOf(nftTokenId1);
+    const beneficiarySft2Owner = await lpSftContract.ownerOf(nftTokenId2);
+
+    chai.expect(deployerSftOwner).to.equal(ethers.constants.AddressZero);
+    chai.expect(beneficiarySft1Owner).to.equal(beneficiaryAddress);
+    chai.expect(beneficiarySft2Owner).to.equal(beneficiaryAddress);
+
+    // Check SFT token IDs
+    const deployerSftTokenIds = await lpSftContract.getTokenIds(
+      deployer.address
+    );
+    const beneficiarySftTokenIds = await lpSftContract.getTokenIds(
+      beneficiaryAddress
+    );
+
+    chai.expect(deployerSftTokenIds.length).to.equal(0);
+    chai.expect(beneficiarySftTokenIds.length).to.equal(2);
+
+    chai.expect(deployerSftTokenIds).to.deep.equal([]);
+    if (beneficiarySftTokenIds[0].eq(nftTokenId1)) {
+      chai
+        .expect(beneficiarySftTokenIds)
+        .to.deep.equal([nftTokenId1, nftTokenId2]);
+    } else {
+      chai
+        .expect(beneficiarySftTokenIds)
+        .to.deep.equal([nftTokenId2, nftTokenId1]);
+    }
+  });
+
+  it("should check base token dust after staking LP NFTs", async function () {
+    this.timeout(60 * 1000);
+
+    const { baseTokenContract } = contracts;
+
+    // Check base token dust
+    const beneficiaryBaseTokenBalance = await baseTokenContract.balanceOf(
+      beneficiaryAddress
+    );
+
+    chai.expect(beneficiaryBaseTokenBalance).to.equal(BASE_TOKEN_DUST);
+  });
+
+  it("should batch transfer SFTs to deployer", async function () {
+    this.timeout(60 * 1000);
+
+    const { lpSftContract } = contracts;
+
+    // Batch transfer SFTs to deployer
+    const tx: Promise<ethers.ContractTransaction> =
+      lpSftContract.safeBatchTransferFrom(
+        beneficiaryAddress, // from
+        deployer.address, // to
+        [nftTokenId1, nftTokenId2], // id
+        [1, 1], // value
+        [] // data
+      );
+
+    // Check path of SFTs
+    await chai.expect(tx).to.emit(lpSftContract, "TransferBatch").withArgs(
+      beneficiaryAddress, // operator
+      beneficiaryAddress, // from
+      deployer.address, // to
+      [nftTokenId1, nftTokenId2], // ids
+      [1, 1] // values
+    );
+  });
+
+  it("should check SFT ownership after batch transfer", async function () {
+    this.timeout(60 * 1000);
+
+    const { lpSftContract } = contracts;
+
+    // Check SFT owners
+    const beneficiarySft1Owner = await lpSftContract.ownerOf(nftTokenId1);
+    const beneficiarySft2Owner = await lpSftContract.ownerOf(nftTokenId2);
+
+    chai.expect(beneficiarySft1Owner).to.equal(deployer.address);
+    chai.expect(beneficiarySft2Owner).to.equal(deployer.address);
+
+    // Check SFT token IDs
+    const deployerSftTokenIds = await lpSftContract.getTokenIds(
+      deployer.address
+    );
+    const beneficiarySftTokenIds = await lpSftContract.getTokenIds(
+      beneficiaryAddress
+    );
+
+    chai.expect(deployerSftTokenIds.length).to.equal(2);
+    chai.expect(beneficiarySftTokenIds.length).to.equal(0);
+
+    if (deployerSftTokenIds[0].eq(nftTokenId1)) {
+      chai
+        .expect(deployerSftTokenIds)
+        .to.deep.equal([nftTokenId1, nftTokenId2]);
+    } else {
+      chai
+        .expect(deployerSftTokenIds)
+        .to.deep.equal([nftTokenId2, nftTokenId1]);
+    }
+    chai.expect(beneficiarySftTokenIds).to.deep.equal([]);
+  });
+
+  it("should fail to unstake first LP NFT", async function () {
+    this.timeout(60 * 1000);
+
+    const { uniV3StakerContract } = contracts;
+
+    // Try to unstake the NFT
+    const tx: Promise<ethers.ContractTransaction> =
+      uniV3StakerContract.exitOneStable(
+        nftTokenId1, // nftTokenId
+        1 // stableIndex
+      );
+
+    chai.expect(tx).to.be.revertedWith("Must own voucher");
+  });
+
+  it("should return SFT 1 back to beneficiary", async function () {
+    this.timeout(60 * 1000);
+
+    const { lpSftContract } = contracts;
+
+    // Transfer SFT 1 to beneficiary
+    const tx1: Promise<ethers.ContractTransaction> = lpSftContract
+      .connect(deployer)
+      .safeTransferFrom(
+        deployer.address, // from
+        beneficiaryAddress, // to
+        nftTokenId1, // id
+        1, // value
+        [] // data
+      );
+
+    // Check SFT path
+    await chai.expect(tx1).to.emit(lpSftContract, "TransferSingle").withArgs(
+      deployer.address, // operator
+      deployer.address, // from
+      beneficiaryAddress, // to
+      nftTokenId1, // id
+      1 // value
+    );
+  });
+
+  it("should check SFT ownership after first return", async function () {
+    this.timeout(60 * 1000);
+
+    const { lpSftContract } = contracts;
+
+    // Check SFT owners
+    const beneficiarySft1Owner = await lpSftContract.ownerOf(nftTokenId1);
+    const beneficiarySft2Owner = await lpSftContract.ownerOf(nftTokenId2);
+
+    chai.expect(beneficiarySft1Owner).to.equal(beneficiaryAddress);
+    chai.expect(beneficiarySft2Owner).to.equal(deployer.address);
+
+    // Check SFT token IDs
+    const deployerSftTokenIds = await lpSftContract.getTokenIds(
+      deployer.address
+    );
+    const beneficiarySftTokenIds = await lpSftContract.getTokenIds(
+      beneficiaryAddress
+    );
+
+    chai.expect(deployerSftTokenIds.length).to.equal(1);
+    chai.expect(beneficiarySftTokenIds.length).to.equal(1);
+
+    chai.expect(deployerSftTokenIds).to.deep.equal([nftTokenId2]);
+    chai.expect(beneficiarySftTokenIds).to.deep.equal([nftTokenId1]);
+  });
+
+  it("should return SFT 2 back to beneficiary", async function () {
+    this.timeout(60 * 1000);
+
+    const { lpSftContract } = contracts;
+
+    // Transfer SFT 2 to beneficiary
+    const tx2: Promise<ethers.ContractTransaction> = lpSftContract
+      .connect(deployer)
+      .safeTransferFrom(
+        deployer.address, // from
+        beneficiaryAddress, // to
+        nftTokenId2, // id
+        1, // value
+        [] // data
+      );
+
+    // Check SFT path
+    await chai.expect(tx2).to.emit(lpSftContract, "TransferSingle").withArgs(
+      deployer.address, // operator
+      deployer.address, // from
+      beneficiaryAddress, // to
+      nftTokenId2, // id
+      1 // value
+    );
+  });
+
+  it("should check NFT and SFT ownerships after second return", async function () {
+    this.timeout(60 * 1000);
+
+    const { lpSftContract } = contracts;
+
+    // Check SFT owners
+    const beneficiarySft1Owner = await lpSftContract.ownerOf(nftTokenId1);
+    const beneficiarySft2Owner = await lpSftContract.ownerOf(nftTokenId2);
+
+    chai.expect(beneficiarySft1Owner).to.equal(beneficiaryAddress);
+    chai.expect(beneficiarySft2Owner).to.equal(beneficiaryAddress);
+
+    // Check SFT token IDs
+    const deployerSftTokenIds = await lpSftContract.getTokenIds(
+      deployer.address
+    );
+    const beneficiarySftTokenIds = await lpSftContract.getTokenIds(
+      beneficiaryAddress
+    );
+
+    chai.expect(deployerSftTokenIds.length).to.equal(0);
+    chai.expect(beneficiarySftTokenIds.length).to.equal(2);
+
+    chai.expect(deployerSftTokenIds).to.deep.equal([]);
+    if (beneficiarySftTokenIds[0].eq(nftTokenId1)) {
+      chai
+        .expect(beneficiarySftTokenIds)
+        .to.deep.equal([nftTokenId1, nftTokenId2]);
+    } else {
+      chai
+        .expect(beneficiarySftTokenIds)
+        .to.deep.equal([nftTokenId2, nftTokenId1]);
+    }
+  });
+
+  it("should unstake the fist LP NFT", async function () {
+    this.timeout(60 * 1000);
+
+    const {
+      lpSftContract,
+      uniswapV3NftManagerContract,
+      uniswapV3StakerContract,
+      uniV3PoolerContract,
+      uniV3StakerContract,
+    } = contracts;
+
+    // Unstake the NFT
+    const tx: Promise<ethers.ContractTransaction> =
+      uniV3StakerContract.exitOneStable(
+        nftTokenId1, // nftTokenId
+        1 // stableIndex
+      );
+
+    //
+    // Check LP SFT path
+    //
+
+    await chai.expect(tx).to.emit(lpSftContract, "TransferSingle").withArgs(
+      uniV3StakerContract.address, // operator
+      beneficiaryAddress, // from
+      ethers.constants.AddressZero, // to
+      nftTokenId1, // tokenId
+      1 // value
+    );
+
+    //
+    // Check LP NFT path
+    //
+
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3NftManagerContract, "Transfer")
+      .withArgs(
+        uniswapV3StakerContract.address, // from
+        uniV3PoolerContract.address, // to
+        nftTokenId1 // tokenId
+      );
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3NftManagerContract, "Transfer")
+      .withArgs(
+        uniV3PoolerContract.address, // from
+        uniV3StakerContract.address, // to
+        nftTokenId1 // tokenId
+      );
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3NftManagerContract, "Transfer")
+      .withArgs(
+        uniV3StakerContract.address, // from
+        beneficiaryAddress, // to
+        nftTokenId1 // tokenId
+      );
+  });
+
+  it("should check SFT ownership after first unstake", async function () {
+    this.timeout(60 * 1000);
+
+    const { lpSftContract } = contracts;
+
+    // Check SFT owners
+    const beneficiarySft1Owner = await lpSftContract.ownerOf(nftTokenId1);
+    const beneficiarySft2Owner = await lpSftContract.ownerOf(nftTokenId2);
+
+    chai.expect(beneficiarySft1Owner).to.equal(ethers.constants.AddressZero);
+    chai.expect(beneficiarySft2Owner).to.equal(beneficiaryAddress);
+
+    // Check SFT token IDs
+    const deployerSftTokenIds = await lpSftContract.getTokenIds(
+      deployer.address
+    );
+    const beneficiarySftTokenIds = await lpSftContract.getTokenIds(
+      beneficiaryAddress
+    );
+
+    chai.expect(deployerSftTokenIds.length).to.equal(0);
+    chai.expect(beneficiarySftTokenIds.length).to.equal(1);
+
+    chai.expect(deployerSftTokenIds).to.deep.equal([]);
+    chai.expect(beneficiarySftTokenIds).to.deep.equal([nftTokenId2]);
+  });
+
+  it("should check USDC balance after unstaking first LP NFT", async function () {
+    this.timeout(60 * 1000);
+
+    const { usdcTokenContract } = contracts;
+
+    const usdcBalance = await usdcTokenContract.balanceOf(beneficiaryAddress);
+    chai.expect(usdcBalance).to.equal(INTERMEDIATE_USDC_BALANCE);
+  });
+
+  it("should unstake the second LP NFT", async function () {
+    this.timeout(60 * 1000);
+
+    const {
+      lpSftContract,
+      uniswapV3NftManagerContract,
+      uniswapV3StakerContract,
+      uniV3PoolerContract,
+      uniV3StakerContract,
+    } = contracts;
+
+    // Unstake the NFT
+    const tx: Promise<ethers.ContractTransaction> =
+      uniV3StakerContract.exitOneStable(
+        nftTokenId2, // nftTokenId
+        1 // stableIndex
+      );
+
+    //
+    // Check LP SFT path
+    //
+
+    await chai.expect(tx).to.emit(lpSftContract, "TransferSingle").withArgs(
+      uniV3StakerContract.address, // operator
+      beneficiaryAddress, // from
+      ethers.constants.AddressZero, // to
+      nftTokenId2, // tokenId
+      1 // value
+    );
+
+    //
+    // Check LP NFT path
+    //
+
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3NftManagerContract, "Transfer")
+      .withArgs(
+        uniswapV3StakerContract.address, // from
+        uniV3PoolerContract.address, // to
+        nftTokenId2 // tokenId
+      );
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3NftManagerContract, "Transfer")
+      .withArgs(
+        uniV3PoolerContract.address, // from
+        uniV3StakerContract.address, // to
+        nftTokenId2 // tokenId
+      );
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3NftManagerContract, "Transfer")
+      .withArgs(
+        uniV3StakerContract.address, // from
+        beneficiaryAddress, // to
+        nftTokenId2 // tokenId
+      );
+  });
+
+  it("should check SFT ownership after second unstake", async function () {
+    this.timeout(60 * 1000);
+
+    const { lpSftContract } = contracts;
+
+    // Check SFT owners
+    const beneficiarySft1Owner = await lpSftContract.ownerOf(nftTokenId1);
+    const beneficiarySft2Owner = await lpSftContract.ownerOf(nftTokenId2);
+
+    chai.expect(beneficiarySft1Owner).to.equal(ethers.constants.AddressZero);
+    chai.expect(beneficiarySft2Owner).to.equal(ethers.constants.AddressZero);
+
+    // Check SFT token IDs
+    const deployerSftTokenIds = await lpSftContract.getTokenIds(
+      deployer.address
+    );
+    const beneficiarySftTokenIds = await lpSftContract.getTokenIds(
+      beneficiaryAddress
+    );
+
+    chai.expect(deployerSftTokenIds.length).to.equal(0);
+    chai.expect(beneficiarySftTokenIds.length).to.equal(0);
+
+    chai.expect(deployerSftTokenIds).to.deep.equal([]);
+    chai.expect(beneficiarySftTokenIds).to.deep.equal([]);
+  });
+
+  it("should make sure we got our money back!!!", async function () {
+    this.timeout(60 * 1000);
+
+    const { usdcTokenContract } = contracts;
+
+    const usdcBalance = await usdcTokenContract.balanceOf(beneficiaryAddress);
+    chai.expect(usdcBalance).to.equal(FINAL_USDC_BALANCE);
+  });
+});

--- a/test/test-uniswap-staker.ts
+++ b/test/test-uniswap-staker.ts
@@ -1,0 +1,1443 @@
+/*
+ * Copyright (C) 2022-2023 Ultrachess team
+ * This file is part of Ultrachess - https://github.com/Ultrachess/contracts
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * See the file LICENSE for more information.
+ */
+
+/* eslint @typescript-eslint/no-unused-vars: "off" */
+
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
+import chai from "chai";
+import { solidity } from "ethereum-waffle";
+import { ethers } from "ethers";
+import * as hardhat from "hardhat";
+
+import { FEE_AMOUNT, TICK_SPACINGS } from "../src/constants";
+import { uniV3StakerAbi } from "../src/contracts/dapp";
+import { ContractLibrary } from "../src/interfaces";
+import { decodeX128Int } from "../src/utils/fixedMath";
+import { extractJSONFromURI } from "../src/utils/lpNftUtils";
+import { setupFixture } from "../src/utils/setupFixture";
+import { getMaxTick, getMinTick } from "../src/utils/tickMath";
+
+// Setup Mocha
+chai.use(solidity);
+
+// Setup Hardhat
+const setupTest = hardhat.deployments.createFixture(setupFixture);
+
+//
+// Test cases
+//
+
+describe("Uniswap V3 Staker", () => {
+  let deployer: SignerWithAddress;
+  let beneficiaryAddress: string;
+  let contracts: ContractLibrary;
+  let baseIsToken0: boolean | undefined; // Read from the Uniswap V3 pool contract
+  let incentiveId: string | undefined; // Read from the Uniswap V3 staker contract
+  let nftTokenId: number | undefined; // Set when first LP NFT is minted
+  let nftTokenId2: number | undefined; // Set when second LP NFT is minted
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Test parameters
+  //////////////////////////////////////////////////////////////////////////////
+
+  // Parameters for staking base token with USDC
+  const REWARD_AMOUNT = ethers.utils.parseUnits("1000", 18); // 1,000 base tokens
+  const REWARD_DELAY_HOURS = 12; // Duration to wait before claiming reward
+  const BASE_TOKEN_AMOUNT = ethers.utils.parseUnits("1000", 18); // 1,000 base tokens
+  const USDC_AMOUNT = ethers.utils.parseUnits("1000", 6); // 1,000 USDC
+  const BASE_TOKENS_POOLED = ethers.BigNumber.from("999698427320457569546"); // About 1,000 base tokens
+  const ASSET_TOKENS_POOLED = ethers.BigNumber.from("999719561164459961015"); // About 1,000 asset tokens
+  const CURVE_AAVE_LP_AMOUNT = ASSET_TOKENS_POOLED; // About 1,000 Curve Aave LP tokens
+  const CURVE_AAVE_GAUGE_SHARES = CURVE_AAVE_LP_AMOUNT; // About 1,000 Curve Aave gauge shares
+  const ASSET_TOKEN_AMOUNT = CURVE_AAVE_GAUGE_SHARES; // About 1,000 asset tokens
+  const UNISWAP_LP_AMOUNT = ethers.BigNumber.from("999708994186612593486"); // About 1,000 units of liquidity
+
+  // Parameters for staking with only USDC
+  const USDC_AMOUNT_2 = USDC_AMOUNT; // 1,000 USDC
+  const CURVE_AAVE_LP_AMOUNT_2 = ethers.BigNumber.from("999719527862979598055"); // About 1,000 Curve Aave LP tokens
+  const CURVE_AAVE_GAUGE_SHARES_2 = CURVE_AAVE_LP_AMOUNT_2; // About 1,000 Curve Aave gauge shares
+  const BASE_TOKENS_BOUGHT = ethers.BigNumber.from("291925506063266129184"); // About 292 base tokens
+  const ASSET_TOKENS_SPENT = ethers.BigNumber.from("416334239074713979427"); // About 416 asset tokens
+  const BASE_DUST_BOUGHT = ethers.BigNumber.from("720441271635113392"); // About 0.721 base tokens
+  const ASSET_DUST_SPENT = ethers.BigNumber.from("1451702247103771910"); // About 1.451 asset tokens
+  const BASE_TOKEN_SHARE = ethers.BigNumber.from("291925506063266129184"); // About 292 base tokens
+  const ASSET_TOKEN_SHARE = ethers.BigNumber.from("581933586541161846718"); // About 582 asset tokens
+  const LIQUIDITY_AMOUNT = ethers.BigNumber.from("412166540061466109560"); // About 412 units of liquidity
+  const ASSET_TOKENS_RECEIVED = ethers.BigNumber.from("411838906035571754157"); // About 412 asset tokens
+
+  // Parameters for unstaking and claiming rewards
+  const CURVE_AAVE_LP_REMOVED = ethers.BigNumber.from("1828503844261893925422"); // About 1,829 Curve Aave LP tokens
+  const CURVE_AAVE_GAUGE_SHARES_UNSTAKED = CURVE_AAVE_LP_REMOVED; // About 1,829 Curve Aave gauge shares
+  const BASE_TOKENS_UNPOOLED = ethers.BigNumber.from("707554880037530330300"); // About 708 base tokens
+  const ASSET_TOKENS_UNPOOLED = ethers.BigNumber.from("1412495484455703549162"); // About 1,412 asset tokens
+  const BASE_TOKENS_COLLECTED = BASE_TOKENS_UNPOOLED; // About 708 base tokens
+  const ASSET_TOKENS_COLLECTED = ethers.BigNumber.from(
+    "1416664938226322171265"
+  ); // About 1,417 asset tokens
+  const USDC_RETURNED = ethers.BigNumber.from("1828265236"); // About 1,828 USDC
+  const BASE_TOKEN_FEES = ethers.BigNumber.from("0");
+  const ASSET_TOKEN_FEES = ethers.BigNumber.from("4170");
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Mocha setup
+  //////////////////////////////////////////////////////////////////////////////
+
+  before(async function () {
+    this.timeout(60 * 1000);
+
+    // Get the Signers
+    [deployer] = await hardhat.ethers.getSigners();
+
+    // Get the beneficiary wallet
+    const namedAccounts: {
+      [name: string]: string;
+    } = await hardhat.getNamedAccounts();
+    beneficiaryAddress = namedAccounts.beneficiary;
+
+    // A single fixture is used for the test suite
+    contracts = await setupTest();
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Setup: Obtain tokens
+  //////////////////////////////////////////////////////////////////////////////
+
+  it("should obtain base token", async function () {
+    this.timeout(60 * 1000);
+
+    const { baseTokenContract } = contracts;
+
+    // Transfer base tokens to beneficiary
+    const tx: Promise<ethers.ContractTransaction> = baseTokenContract
+      .connect(deployer)
+      .transfer(beneficiaryAddress, BASE_TOKEN_AMOUNT);
+    await (await tx).wait();
+
+    const baseTokenBalance: ethers.BigNumber =
+      await baseTokenContract.balanceOf(beneficiaryAddress);
+    chai.expect(baseTokenBalance).to.equal(BASE_TOKEN_AMOUNT);
+  });
+
+  it("should obtain USDC", async function () {
+    this.timeout(60 * 1000);
+
+    const { usdcTokenContract } = contracts;
+
+    // Mint USDC
+    const tx: Promise<ethers.ContractTransaction> = usdcTokenContract.mint(
+      beneficiaryAddress,
+      USDC_AMOUNT.add(USDC_AMOUNT_2)
+    );
+    await (await tx).wait();
+
+    const usdcBalance = await usdcTokenContract.balanceOf(beneficiaryAddress);
+    chai.expect(usdcBalance).to.equal(USDC_AMOUNT.add(USDC_AMOUNT_2));
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Test Uniswap V3 Pool
+  //////////////////////////////////////////////////////////////////////////////
+
+  it("should read token addresses from UniV3 pool", async function () {
+    this.timeout(60 * 1000);
+
+    const { assetTokenContract, baseTokenContract, uniswapV3PoolContract } =
+      contracts;
+
+    const token0Address: string = await uniswapV3PoolContract.token0();
+    const token1Address: string = await uniswapV3PoolContract.token1();
+
+    if (
+      ethers.BigNumber.from(baseTokenContract.address).lt(
+        ethers.BigNumber.from(assetTokenContract.address)
+      )
+    ) {
+      // Base token is token0
+      // Asset token is token1
+      console.log("    Token pair: CHESS/ultra3CRV");
+      baseIsToken0 = true;
+      chai.expect(token0Address).to.hexEqual(baseTokenContract.address);
+      chai.expect(token1Address).to.hexEqual(assetTokenContract.address);
+    } else {
+      // Asset token is token0
+      // Base token is token1
+      console.log("    Token pair: ultra3CRV/CHESS");
+      baseIsToken0 = false;
+      chai.expect(token0Address).to.hexEqual(assetTokenContract.address);
+      chai.expect(token1Address).to.hexEqual(baseTokenContract.address);
+    }
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Test Uniswap V3 Staker
+  //////////////////////////////////////////////////////////////////////////////
+
+  it("should check UniswapV3Staker", async function () {
+    this.timeout(60 * 1000);
+
+    const {
+      uniswapV3FactoryContract,
+      uniswapV3NftManagerContract,
+      uniswapV3StakerContract,
+    } = contracts;
+
+    // Test UniswapV3Staker
+    const uniswapV3FactoryAddress = await uniswapV3StakerContract.factory();
+    const uniswapV3NftManagerAddress =
+      await uniswapV3StakerContract.nonfungiblePositionManager();
+    const maxIncentiveStartLeadTime =
+      await uniswapV3StakerContract.maxIncentiveStartLeadTime();
+    const maxIncentiveDuration =
+      await uniswapV3StakerContract.maxIncentiveDuration();
+
+    chai
+      .expect(uniswapV3FactoryAddress)
+      .to.equal(uniswapV3FactoryContract.address);
+    chai
+      .expect(uniswapV3NftManagerAddress)
+      .to.equal(uniswapV3NftManagerContract.address);
+    chai.expect(maxIncentiveStartLeadTime).to.equal(0);
+    chai.expect(maxIncentiveDuration).to.equal(ethers.constants.MaxUint256); // TODO: Maybe (86400 * 365)?
+  });
+
+  it("should check UniV3Staker", async function () {
+    this.timeout(60 * 1000);
+
+    const { uniswapV3StakerContract, uniV3StakerContract } = contracts;
+
+    // Test UniV3Staker
+    const uniswapV3StakerAddress = await uniV3StakerContract.uniswapV3Staker();
+
+    chai
+      .expect(uniswapV3StakerAddress)
+      .to.equal(uniswapV3StakerContract.address);
+  });
+
+  it("should check the UniV3 staker incentive", async function () {
+    this.timeout(60 * 1000);
+
+    const { baseTokenContract, uniV3StakerContract, uniswapV3PoolContract } =
+      contracts;
+
+    // Read back the incentive information
+    incentiveId = await uniV3StakerContract.incentiveId();
+    const incetiveKey = await uniV3StakerContract.incentiveKey();
+    const [rewardToken, pool, startTime, endTime, refundee] = incetiveKey;
+
+    chai.expect(rewardToken).to.equal(baseTokenContract.address);
+    chai.expect(pool).to.equal(uniswapV3PoolContract.address);
+    chai.expect(refundee).to.equal(uniV3StakerContract.address);
+  });
+
+  it("should check incentive", async function () {
+    this.timeout(60 * 1000);
+
+    const { uniV3StakerContract } = contracts;
+
+    const [totalRewardUnclaimed, totalSecondsClaimedX128, numberOfStakes] =
+      await uniV3StakerContract.getIncentive();
+
+    chai.expect(totalRewardUnclaimed).to.equal(REWARD_AMOUNT);
+    chai.expect(totalSecondsClaimedX128).to.equal(0);
+    chai.expect(numberOfStakes).to.equal(0);
+  });
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Test Uniswap V3 LP NFTs
+  //////////////////////////////////////////////////////////////////////////////
+
+  it("should approve UniV3 staker spending base token", async function () {
+    this.timeout(60 * 1000);
+
+    const { baseTokenContract, uniV3StakerContract } = contracts;
+
+    const tx: Promise<ethers.ContractTransaction> = baseTokenContract.approve(
+      uniV3StakerContract.address, // spender
+      BASE_TOKEN_AMOUNT // amount
+    );
+    await chai.expect(tx).to.emit(baseTokenContract, "Approval").withArgs(
+      beneficiaryAddress, // owner
+      uniV3StakerContract.address, // spender
+      BASE_TOKEN_AMOUNT // value
+    );
+  });
+
+  it("should approve UniV3 staker spending USDC", async function () {
+    this.timeout(60 * 1000);
+
+    const { uniV3StakerContract, usdcTokenContract } = contracts;
+
+    const tx: Promise<ethers.ContractTransaction> = usdcTokenContract.approve(
+      uniV3StakerContract.address, // spender
+      USDC_AMOUNT // value
+    );
+    await chai.expect(tx).to.emit(usdcTokenContract, "Approval").withArgs(
+      beneficiaryAddress, // owner
+      uniV3StakerContract.address, // spender
+      USDC_AMOUNT // value
+    );
+  });
+
+  it("should stake an LP NFT with base token and USDC", async function () {
+    this.timeout(60 * 1000);
+
+    const {
+      assetTokenContract,
+      ausdcTokenProxyContract,
+      baseTokenContract,
+      curveAaveGaugeContract,
+      curveAaveLpTokenContract,
+      curveAavePoolContract,
+      curveAavePoolerContract,
+      curveAaveStakerContract,
+      lpSftContract,
+      uniswapV3NftManagerContract,
+      uniswapV3PoolContract,
+      uniswapV3StakerContract,
+      uniV3PoolerContract,
+      uniV3StakerContract,
+      usdcTokenContract,
+    } = contracts;
+
+    // Deposit tokens and stake the NFT
+    const tx: Promise<ethers.ContractTransaction> =
+      uniV3StakerContract.stakeNFTImbalance(
+        [0, USDC_AMOUNT, 0], // stableAmounts
+        BASE_TOKEN_AMOUNT, // baseTokenAmount
+        beneficiaryAddress // recipient
+      );
+
+    // Get NFT token ID
+    const receipt: ethers.ContractReceipt = await (await tx).wait();
+    const iface: ethers.utils.Interface = new ethers.utils.Interface(
+      uniV3StakerAbi
+    );
+    const log = receipt.logs.find((log) => {
+      try {
+        return iface.parseLog(log).name === "NFTStaked";
+      } catch (e) {
+        return false;
+      }
+    });
+    const logDescription: ethers.utils.LogDescription = iface.parseLog(log);
+    nftTokenId = logDescription.args[3].toNumber();
+    console.log("    LP NFT token ID:", nftTokenId);
+
+    //
+    // Check routing events
+    //
+
+    await chai
+      .expect(tx)
+      .to.emit(curveAavePoolerContract, "LiquidityAdded")
+      .withArgs(
+        curveAaveStakerContract.address, // sender
+        curveAaveStakerContract.address, // recipient
+        [0, USDC_AMOUNT, 0], // stableAmounts
+        CURVE_AAVE_LP_AMOUNT // lpTokenAmount
+      );
+    await chai
+      .expect(tx)
+      .to.emit(curveAaveStakerContract, "GaugeStaked")
+      .withArgs(
+        uniV3PoolerContract.address, // sender
+        uniV3PoolerContract.address, // recipient
+        [0, USDC_AMOUNT, 0], // stableAmounts
+        CURVE_AAVE_GAUGE_SHARES // gaugeShares
+      );
+    await chai.expect(tx).to.emit(uniV3PoolerContract, "NFTMinted").withArgs(
+      uniV3StakerContract.address, // sender
+      uniV3StakerContract.address, // recipient
+      uniswapV3NftManagerContract.address, // nftAddress
+      nftTokenId, // nftTokenId
+      [0, USDC_AMOUNT, 0], // stableAmounts
+      BASE_TOKEN_AMOUNT, // baseTokenAmount
+      BASE_TOKENS_POOLED, // baseTokenShare
+      ASSET_TOKENS_POOLED, // assetTokenShare
+      UNISWAP_LP_AMOUNT // liquidityAmount
+    );
+    await chai.expect(tx).to.emit(uniV3StakerContract, "NFTStaked").withArgs(
+      beneficiaryAddress, // sender
+      beneficiaryAddress, // recipient
+      uniswapV3NftManagerContract.address, // nftAddress
+      nftTokenId, // nftTokenId
+      [0, USDC_AMOUNT, 0], // stableAmounts
+      BASE_TOKEN_AMOUNT // baseTokenAmount
+    );
+
+    //
+    // Check Uniswap NFT manager events
+    //
+
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3NftManagerContract, "IncreaseLiquidity")
+      .withArgs(
+        nftTokenId, // tokenId
+        UNISWAP_LP_AMOUNT, // liquidity
+        baseIsToken0 ? BASE_TOKENS_POOLED : ASSET_TOKENS_POOLED, // amount0
+        baseIsToken0 ? ASSET_TOKENS_POOLED : BASE_TOKENS_POOLED // amount1
+      );
+
+    //
+    // Check Uniswap staker events
+    //
+
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3StakerContract, "DepositTransferred")
+      .withArgs(
+        nftTokenId, // tokenId
+        ethers.constants.AddressZero, // oldOwner
+        uniV3StakerContract.address // newOwner
+      );
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3StakerContract, "TokenStaked")
+      .withArgs(
+        nftTokenId, // tokenId
+        incentiveId, // incentiveId
+        UNISWAP_LP_AMOUNT // liquidity
+      );
+
+    //
+    // Check LP NFT path
+    //
+
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3NftManagerContract, "Transfer")
+      .withArgs(
+        ethers.constants.AddressZero, // from
+        uniV3StakerContract.address, // to
+        nftTokenId // tokenId
+      );
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3NftManagerContract, "Transfer")
+      .withArgs(
+        uniV3StakerContract.address, // from
+        uniswapV3StakerContract.address, // to
+        nftTokenId // tokenId
+      );
+
+    //
+    // Check LP SFT path
+    //
+
+    await chai.expect(tx).to.emit(lpSftContract, "TransferSingle").withArgs(
+      uniV3StakerContract.address, // operator
+      ethers.constants.AddressZero, // from
+      beneficiaryAddress, // to
+      nftTokenId, // id
+      1 // value
+    );
+
+    //
+    // Check USDC path
+    //
+
+    await chai.expect(tx).to.emit(usdcTokenContract, "Transfer").withArgs(
+      beneficiaryAddress, // from
+      uniV3StakerContract.address, // to
+      USDC_AMOUNT // value
+    );
+    await chai.expect(tx).to.emit(usdcTokenContract, "Transfer").withArgs(
+      uniV3StakerContract.address, // from
+      uniV3PoolerContract.address, // to
+      USDC_AMOUNT // value
+    );
+    await chai.expect(tx).to.emit(usdcTokenContract, "Transfer").withArgs(
+      uniV3PoolerContract.address, // from
+      curveAaveStakerContract.address, // to
+      USDC_AMOUNT // value
+    );
+    await chai.expect(tx).to.emit(usdcTokenContract, "Transfer").withArgs(
+      curveAaveStakerContract.address, // from
+      curveAavePoolerContract.address, // to
+      USDC_AMOUNT // value
+    );
+    await chai.expect(tx).to.emit(usdcTokenContract, "Transfer").withArgs(
+      curveAaveStakerContract.address, // from
+      curveAavePoolerContract.address, // to
+      USDC_AMOUNT // value
+    );
+    await chai.expect(tx).to.emit(usdcTokenContract, "Transfer").withArgs(
+      curveAavePoolerContract.address, // from
+      curveAavePoolContract.address, // to
+      USDC_AMOUNT // value
+    );
+    await chai.expect(tx).to.emit(usdcTokenContract, "Transfer").withArgs(
+      curveAavePoolContract.address, // from
+      ausdcTokenProxyContract.address, // to
+      USDC_AMOUNT // value
+    );
+
+    //
+    // Check Curve Aave LP path
+    //
+
+    await chai
+      .expect(tx)
+      .to.emit(curveAaveLpTokenContract, "Transfer")
+      .withArgs(
+        ethers.constants.AddressZero, // from
+        curveAavePoolerContract.address, // to
+        CURVE_AAVE_LP_AMOUNT // value
+      );
+    await chai
+      .expect(tx)
+      .to.emit(curveAaveLpTokenContract, "Transfer")
+      .withArgs(
+        curveAavePoolerContract.address, // from
+        curveAaveStakerContract.address, // to
+        CURVE_AAVE_LP_AMOUNT // value
+      );
+    await chai
+      .expect(tx)
+      .to.emit(curveAaveLpTokenContract, "Approval")
+      .withArgs(
+        curveAaveStakerContract.address, // owner
+        curveAaveGaugeContract.address, // spender
+        CURVE_AAVE_LP_AMOUNT // value
+      );
+    await chai
+      .expect(tx)
+      .to.emit(curveAaveLpTokenContract, "Transfer")
+      .withArgs(
+        curveAaveStakerContract.address, // from
+        curveAaveGaugeContract.address, // to
+        CURVE_AAVE_LP_AMOUNT // value
+      );
+
+    //
+    // Check asset token path
+    //
+
+    await chai.expect(tx).to.emit(assetTokenContract, "Transfer").withArgs(
+      ethers.constants.AddressZero, // from
+      uniV3PoolerContract.address, // to
+      ASSET_TOKEN_AMOUNT // value
+    );
+    await chai.expect(tx).to.emit(assetTokenContract, "Transfer").withArgs(
+      uniV3PoolerContract.address, // from
+      uniswapV3PoolContract.address, // to
+      ASSET_TOKEN_AMOUNT // value
+    );
+
+    //
+    // Check base token path
+    //
+
+    await chai.expect(tx).to.emit(baseTokenContract, "Transfer").withArgs(
+      beneficiaryAddress, // from
+      uniV3StakerContract.address, // to
+      BASE_TOKEN_AMOUNT // value
+    );
+    await chai.expect(tx).to.emit(baseTokenContract, "Transfer").withArgs(
+      uniV3StakerContract.address, // from
+      uniV3PoolerContract.address, // to
+      BASE_TOKEN_AMOUNT // value
+    );
+    await chai.expect(tx).to.emit(baseTokenContract, "Transfer").withArgs(
+      uniV3PoolerContract.address, // from
+      uniswapV3PoolContract.address, // to
+      BASE_TOKENS_POOLED // value
+    );
+  });
+
+  it("should check total LP NFT balance", async function () {
+    this.timeout(60 * 1000);
+
+    const { uniswapV3NftManagerContract, uniswapV3StakerContract } = contracts;
+
+    const nftBalance = await uniswapV3NftManagerContract.balanceOf(
+      uniswapV3StakerContract.address
+    );
+    chai.expect(nftBalance.toNumber()).to.equal(1);
+  });
+
+  it("should check LP NFT position after minting", async function () {
+    this.timeout(60 * 1000);
+
+    const {
+      assetTokenContract,
+      baseTokenContract,
+      uniswapV3NftManagerContract,
+    } = contracts;
+
+    const position = await uniswapV3NftManagerContract.positions(nftTokenId);
+    const [
+      nonce,
+      operator,
+      token0,
+      token1,
+      fee,
+      tickLower,
+      tickUpper,
+      liquidity,
+      feeGrowthInside0LastX128,
+      feeGrowthInside1LastX128,
+      tokensOwed0,
+      tokensOwed1,
+    ] = position;
+
+    chai.expect(nonce).to.eq(0);
+    chai.expect(operator).to.eq(ethers.constants.AddressZero); // TODO: Why is this address(0)?
+    if (baseIsToken0) {
+      chai.expect(token0).to.eq(baseTokenContract.address);
+      chai.expect(token1).to.eq(assetTokenContract.address);
+    } else {
+      chai.expect(token0).to.eq(assetTokenContract.address);
+      chai.expect(token1).to.eq(baseTokenContract.address);
+    }
+    chai.expect(fee).to.eq(FEE_AMOUNT.HIGH);
+    chai.expect(tickLower).to.eq(getMinTick(TICK_SPACINGS[FEE_AMOUNT.HIGH]));
+    chai.expect(tickUpper).to.eq(getMaxTick(TICK_SPACINGS[FEE_AMOUNT.HIGH]));
+    chai.expect(liquidity).to.eq(UNISWAP_LP_AMOUNT);
+    chai.expect(feeGrowthInside0LastX128).to.eq(0);
+    chai.expect(feeGrowthInside1LastX128).to.be.gt(0);
+    chai.expect(tokensOwed0).to.eq(0);
+    chai.expect(tokensOwed1).to.eq(0);
+  });
+
+  it("should check LP NFT URI", async function () {
+    this.timeout(60 * 1000);
+
+    const { uniswapV3NftManagerContract } = contracts;
+
+    const nftTokenUri = await uniswapV3NftManagerContract.tokenURI(nftTokenId);
+
+    // Check that data URI has correct mime type
+    chai.expect(nftTokenUri).to.match(/data:application\/json;base64,.+/);
+
+    // Content should be valid JSON and structure
+    const nftContent = extractJSONFromURI(nftTokenUri);
+    chai.expect(nftContent).to.haveOwnProperty("name").is.a("string");
+    chai.expect(nftContent).to.haveOwnProperty("description").is.a("string");
+    chai.expect(nftContent).to.haveOwnProperty("image").is.a("string");
+  });
+
+  it("should check LP SFT URI", async function () {
+    this.timeout(60 * 1000);
+
+    const { lpSftContract } = contracts;
+
+    const sftTokenUri = await lpSftContract.uri(nftTokenId);
+
+    // Check that data URI has correct mime type
+    chai.expect(sftTokenUri).to.match(/data:application\/json;base64,.+/);
+
+    // Content should be valid JSON and structure
+    const sftContent = extractJSONFromURI(sftTokenUri);
+    chai.expect(sftContent).to.haveOwnProperty("name").is.a("string");
+    chai.expect(sftContent).to.haveOwnProperty("description").is.a("string");
+    chai.expect(sftContent).to.haveOwnProperty("image").is.a("string");
+
+    console.log(`    LP SFT token name: ${sftContent.name}`);
+    // console.log(`    LP SFT token image: ${content.image}`);
+  });
+
+  it("should check incentive", async function () {
+    this.timeout(60 * 1000);
+
+    const { uniV3StakerContract } = contracts;
+
+    const [totalRewardUnclaimed, totalSecondsClaimedX128, numberOfStakes] =
+      await uniV3StakerContract.getIncentive();
+
+    chai.expect(totalRewardUnclaimed).to.equal(REWARD_AMOUNT);
+    chai.expect(totalSecondsClaimedX128).to.equal(0);
+    chai.expect(numberOfStakes).to.equal(1);
+  });
+
+  it("should check stake", async function () {
+    this.timeout(60 * 1000);
+
+    const { uniV3StakerContract } = contracts;
+
+    const [secondsPerLiquidityInsideInitialX128, liquidity] =
+      await uniV3StakerContract.getStake(nftTokenId);
+
+    chai.expect(secondsPerLiquidityInsideInitialX128).to.be.gt(0);
+    chai.expect(liquidity).to.equal(UNISWAP_LP_AMOUNT);
+  });
+
+  it("should check deposit", async function () {
+    this.timeout(60 * 1000);
+
+    const { uniV3StakerContract } = contracts;
+
+    const [owner, numberOfStakes, tickLower, tickUpper] =
+      await uniV3StakerContract.getDeposit(nftTokenId);
+
+    chai.expect(owner).to.equal(beneficiaryAddress);
+    chai.expect(numberOfStakes).to.equal(1);
+    chai.expect(tickLower).to.equal(getMinTick(TICK_SPACINGS[FEE_AMOUNT.HIGH]));
+    chai.expect(tickUpper).to.equal(getMaxTick(TICK_SPACINGS[FEE_AMOUNT.HIGH]));
+  });
+
+  it("should check rewards", async function () {
+    this.timeout(60 * 1000);
+
+    const { uniV3StakerContract } = contracts;
+
+    // TODO
+    const rewardsOwed = await uniV3StakerContract.getRewardsOwed(
+      beneficiaryAddress
+    );
+
+    chai.expect(rewardsOwed).to.equal(0);
+  });
+
+  it("should check reward info for LP NFT", async function () {
+    this.timeout(60 * 1000);
+
+    const { uniV3StakerContract } = contracts;
+
+    const [reward, secondsInsideX128] =
+      await uniV3StakerContract.callStatic.getRewardInfo(nftTokenId);
+
+    chai.expect(reward).to.equal(0);
+    chai.expect(secondsInsideX128).to.equal(0);
+  });
+
+  it(`should advance time ${REWARD_DELAY_HOURS} hours`, async function () {
+    this.timeout(60 * 1000);
+
+    // Add 12 hours and mine the next block
+    await hardhat.network.provider.send("evm_increaseTime", [
+      REWARD_DELAY_HOURS * 60 * 60,
+    ]);
+    await hardhat.network.provider.send("evm_mine");
+  });
+
+  it("should check reward info for LP NFT", async function () {
+    this.timeout(60 * 1000);
+
+    const { uniV3StakerContract } = contracts;
+
+    const [reward, secondsInsideX128] =
+      await uniV3StakerContract.callStatic.getRewardInfo(nftTokenId);
+
+    const secondsInside: number = decodeX128Int(secondsInsideX128).toNumber();
+
+    chai.expect(reward).to.not.equal(0);
+    chai
+      .expect(secondsInside)
+      .to.be.at.least((REWARD_DELAY_HOURS * 60 - 1) * 60);
+  });
+
+  it("should approve UniV3 staker spending USDC", async function () {
+    this.timeout(60 * 1000);
+
+    const { uniV3StakerContract, usdcTokenContract } = contracts;
+
+    const tx: Promise<ethers.ContractTransaction> = usdcTokenContract.approve(
+      uniV3StakerContract.address, // spender
+      USDC_AMOUNT // value
+    );
+    await chai.expect(tx).to.emit(usdcTokenContract, "Approval").withArgs(
+      beneficiaryAddress, // owner
+      uniV3StakerContract.address, // spender
+      USDC_AMOUNT // value
+    );
+  });
+
+  it("should stake an LP NFT with only USDC", async function () {
+    this.timeout(60 * 1000);
+
+    const {
+      assetTokenContract,
+      ausdcTokenProxyContract,
+      baseTokenContract,
+      curveAaveGaugeContract,
+      curveAaveLpTokenContract,
+      curveAavePoolContract,
+      curveAavePoolerContract,
+      curveAaveStakerContract,
+      lpSftContract,
+      uniswapV3NftManagerContract,
+      uniswapV3PoolContract,
+      uniswapV3StakerContract,
+      uniV3PoolerContract,
+      uniV3StakerContract,
+      uniV3SwapperContract,
+      usdcTokenContract,
+    } = contracts;
+
+    // Deposit tokens and stake the NFT
+    const tx: Promise<ethers.ContractTransaction> =
+      uniV3StakerContract.stakeNFTWithStables(
+        [0, USDC_AMOUNT_2, 0], // stableAmounts
+        beneficiaryAddress // recipient
+      );
+
+    // Get NFT token ID
+    const receipt: ethers.ContractReceipt = await (await tx).wait();
+    const iface: ethers.utils.Interface = new ethers.utils.Interface(
+      uniV3StakerAbi
+    );
+    const log = receipt.logs.find((log) => {
+      try {
+        return iface.parseLog(log).name === "NFTStaked";
+      } catch (e) {
+        return false;
+      }
+    });
+    const logDescription: ethers.utils.LogDescription = iface.parseLog(log);
+    nftTokenId2 = logDescription.args[3].toNumber();
+    console.log("    LP NFT 2 token ID:", nftTokenId2);
+
+    //
+    // Check routing events
+    //
+
+    await chai
+      .expect(tx)
+      .to.emit(curveAavePoolerContract, "LiquidityAdded")
+      .withArgs(
+        curveAaveStakerContract.address, // sender
+        curveAaveStakerContract.address, // recipient
+        [0, USDC_AMOUNT_2, 0], // stableAmounts
+        CURVE_AAVE_LP_AMOUNT_2 // lpTokenAmount
+      );
+    await chai
+      .expect(tx)
+      .to.emit(curveAaveStakerContract, "GaugeStaked")
+      .withArgs(
+        uniV3PoolerContract.address, // sender
+        uniV3PoolerContract.address, // recipient
+        [0, USDC_AMOUNT_2, 0], // stableAmounts
+        CURVE_AAVE_GAUGE_SHARES_2 // gaugeShares
+      );
+    await chai
+      .expect(tx)
+      .to.emit(uniV3SwapperContract, "TokensBought")
+      .withArgs(
+        uniV3PoolerContract.address, // sender
+        uniV3PoolerContract.address, // recipient
+        [0, 0, 0], // stableAmounts
+        ASSET_TOKENS_SPENT, // assetTokenAmount
+        BASE_TOKENS_BOUGHT // baseTokenReturned
+      );
+    await chai.expect(tx).to.emit(uniV3PoolerContract, "NFTMinted").withArgs(
+      uniV3StakerContract.address, // sender
+      uniV3StakerContract.address, // recipient
+      uniswapV3NftManagerContract.address, // nftAddress
+      nftTokenId2, // nftTokenId
+      [0, USDC_AMOUNT_2, 0], // stableAmounts
+      0, // baseTokenAmount
+      BASE_TOKEN_SHARE, // baseTokenShare
+      ASSET_TOKEN_SHARE, // assetTokenShare
+      LIQUIDITY_AMOUNT // liquidityAmount
+    );
+    await chai.expect(tx).to.emit(uniV3StakerContract, "NFTStaked").withArgs(
+      beneficiaryAddress, // sender
+      beneficiaryAddress, // recipient
+      uniswapV3NftManagerContract.address, // nftAddress
+      nftTokenId2, // nftTokenId
+      [0, USDC_AMOUNT_2, 0], // stableAmounts
+      0 // baseTokenAmount
+    );
+    await chai
+      .expect(tx)
+      .to.emit(uniV3SwapperContract, "TokensBought")
+      .withArgs(
+        uniV3PoolerContract.address, // sender
+        uniV3PoolerContract.address, // recipient
+        [0, 0, 0], // stableAmounts
+        ASSET_DUST_SPENT, // assetTokenAmount
+        BASE_DUST_BOUGHT // baseTokenReturned
+      );
+
+    //
+    // Check Uniswap NFT manager events
+    //
+
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3NftManagerContract, "IncreaseLiquidity")
+      .withArgs(
+        nftTokenId2, // tokenId
+        LIQUIDITY_AMOUNT, // liquidity
+        baseIsToken0 ? BASE_TOKEN_SHARE : ASSET_TOKEN_SHARE, // amount0
+        baseIsToken0 ? ASSET_TOKEN_SHARE : BASE_TOKEN_SHARE // amount1
+      );
+
+    //
+    // Check Uniswap staker events
+    //
+
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3StakerContract, "DepositTransferred")
+      .withArgs(
+        nftTokenId2, // tokenId
+        ethers.constants.AddressZero, // oldOwner
+        uniV3StakerContract.address // newOwner
+      );
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3StakerContract, "TokenStaked")
+      .withArgs(
+        nftTokenId2, // tokenId
+        incentiveId, // incentiveId
+        LIQUIDITY_AMOUNT // liquidity
+      );
+
+    //
+    // Check LP NFT path
+    //
+
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3NftManagerContract, "Transfer")
+      .withArgs(
+        ethers.constants.AddressZero, // from
+        uniV3StakerContract.address, // to
+        nftTokenId2 // tokenId
+      );
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3NftManagerContract, "Transfer")
+      .withArgs(
+        uniV3StakerContract.address, // from
+        uniswapV3StakerContract.address, // to
+        nftTokenId2 // tokenId
+      );
+
+    //
+    // Check LP SFT path
+    //
+
+    await chai.expect(tx).to.emit(lpSftContract, "TransferSingle").withArgs(
+      uniV3StakerContract.address, // operator
+      ethers.constants.AddressZero, // from
+      beneficiaryAddress, // to
+      nftTokenId2, // id
+      1 // value
+    );
+
+    //
+    // Check USDC path
+    //
+
+    await chai.expect(tx).to.emit(usdcTokenContract, "Transfer").withArgs(
+      beneficiaryAddress, // from
+      uniV3StakerContract.address, // to
+      USDC_AMOUNT_2 // value
+    );
+    await chai.expect(tx).to.emit(usdcTokenContract, "Transfer").withArgs(
+      uniV3StakerContract.address, // from
+      uniV3PoolerContract.address, // to
+      USDC_AMOUNT_2 // value
+    );
+    await chai.expect(tx).to.emit(usdcTokenContract, "Transfer").withArgs(
+      uniV3PoolerContract.address, // from
+      curveAaveStakerContract.address, // to
+      USDC_AMOUNT_2 // value
+    );
+    await chai.expect(tx).to.emit(usdcTokenContract, "Transfer").withArgs(
+      curveAaveStakerContract.address, // from
+      curveAavePoolerContract.address, // to
+      USDC_AMOUNT_2 // value
+    );
+    await chai.expect(tx).to.emit(usdcTokenContract, "Transfer").withArgs(
+      curveAaveStakerContract.address, // from
+      curveAavePoolerContract.address, // to
+      USDC_AMOUNT_2 // value
+    );
+    await chai.expect(tx).to.emit(usdcTokenContract, "Transfer").withArgs(
+      curveAavePoolerContract.address, // from
+      curveAavePoolContract.address, // to
+      USDC_AMOUNT_2 // value
+    );
+    await chai.expect(tx).to.emit(usdcTokenContract, "Transfer").withArgs(
+      curveAavePoolContract.address, // from
+      ausdcTokenProxyContract.address, // to
+      USDC_AMOUNT_2 // value
+    );
+
+    //
+    // Check Curve Aave LP path
+    //
+
+    await chai
+      .expect(tx)
+      .to.emit(curveAaveLpTokenContract, "Transfer")
+      .withArgs(
+        ethers.constants.AddressZero, // from
+        curveAavePoolerContract.address, // to
+        CURVE_AAVE_LP_AMOUNT_2 // value
+      );
+    await chai
+      .expect(tx)
+      .to.emit(curveAaveLpTokenContract, "Transfer")
+      .withArgs(
+        curveAavePoolerContract.address, // from
+        curveAaveStakerContract.address, // to
+        CURVE_AAVE_LP_AMOUNT_2 // value
+      );
+    await chai
+      .expect(tx)
+      .to.emit(curveAaveLpTokenContract, "Approval")
+      .withArgs(
+        curveAaveStakerContract.address, // owner
+        curveAaveGaugeContract.address, // spender
+        CURVE_AAVE_LP_AMOUNT_2 // value
+      );
+    await chai
+      .expect(tx)
+      .to.emit(curveAaveLpTokenContract, "Transfer")
+      .withArgs(
+        curveAaveStakerContract.address, // from
+        curveAaveGaugeContract.address, // to
+        CURVE_AAVE_LP_AMOUNT_2 // value
+      );
+
+    //
+    // Check asset token path
+    //
+
+    /*
+    await chai.expect(tx).to.emit(assetTokenContract, "Transfer").withArgs(
+      ethers.constants.AddressZero, // from
+      uniV3PoolerContract.address, // to
+      CURVE_AAVE_LP_AMOUNT_2 // value
+    );
+    await chai.expect(tx).to.emit(assetTokenContract, "Transfer").withArgs(
+      uniV3PoolerContract.address, // from
+      uniV3SwapperContract.address, // to
+      ASSET_TOKEN_AMOUNT_2 // value
+    );
+    await chai.expect(tx).to.emit(assetTokenContract, "Transfer").withArgs(
+      uniV3SwapperContract.address, // from
+      uniswapV3PoolContract.address, // to
+      ASSET_TOKEN_AMOUNT_2 // value
+    );
+    await chai.expect(tx).to.emit(assetTokenContract, "Transfer").withArgs(
+      uniV3PoolerContract.address, // from
+      uniswapV3PoolContract.address, // to
+      ASSET_TOKEN_AMOUNT_2 // value
+    );
+
+    //
+    // Check base token path
+    //
+
+    await chai.expect(tx).to.emit(baseTokenContract, "Transfer").withArgs(
+      uniswapV3PoolContract.address, // from
+      uniV3SwapperContract.address, // to
+      BASE_TOKEN_AMOUNT_2 // value
+    );
+    await chai.expect(tx).to.emit(baseTokenContract, "Transfer").withArgs(
+      uniV3SwapperContract.address, // from
+      uniV3PoolerContract.address, // to
+      BASE_TOKEN_AMOUNT_2 // value
+    );
+    await chai.expect(tx).to.emit(baseTokenContract, "Transfer").withArgs(
+      uniV3PoolerContract.address, // from
+      uniswapV3PoolContract.address, // to
+      BASE_TOKEN_AMOUNT_3 // value
+    );
+    */
+  });
+
+  it("should check total LP NFT balance", async function () {
+    this.timeout(60 * 1000);
+
+    const { uniswapV3NftManagerContract, uniswapV3StakerContract } = contracts;
+
+    const nftBalance = await uniswapV3NftManagerContract.balanceOf(
+      uniswapV3StakerContract.address
+    );
+    chai.expect(nftBalance).to.equal(2);
+  });
+
+  it("should check LP NFT position after swapping", async function () {
+    this.timeout(60 * 1000);
+
+    const {
+      assetTokenContract,
+      baseTokenContract,
+      uniswapV3NftManagerContract,
+    } = contracts;
+
+    const position = await uniswapV3NftManagerContract.positions(nftTokenId);
+    const [
+      nonce,
+      operator,
+      token0,
+      token1,
+      fee,
+      tickLower,
+      tickUpper,
+      liquidity,
+      feeGrowthInside0LastX128,
+      feeGrowthInside1LastX128,
+      tokensOwed0,
+      tokensOwed1,
+    ] = position;
+
+    chai.expect(nonce).to.eq(0);
+    chai.expect(operator).to.eq(ethers.constants.AddressZero); // TODO: Why is this address(0)?
+    if (baseIsToken0) {
+      chai.expect(token0).to.eq(baseTokenContract.address);
+      chai.expect(token1).to.eq(assetTokenContract.address);
+    } else {
+      chai.expect(token0).to.eq(assetTokenContract.address);
+      chai.expect(token1).to.eq(baseTokenContract.address);
+    }
+    chai.expect(fee).to.eq(FEE_AMOUNT.HIGH);
+    chai.expect(tickLower).to.eq(getMinTick(TICK_SPACINGS[FEE_AMOUNT.HIGH]));
+    chai.expect(tickUpper).to.eq(getMaxTick(TICK_SPACINGS[FEE_AMOUNT.HIGH]));
+    chai.expect(liquidity).to.eq(UNISWAP_LP_AMOUNT);
+    chai.expect(feeGrowthInside0LastX128).to.eq(0);
+    chai.expect(feeGrowthInside1LastX128).to.be.gt(0);
+    chai.expect(tokensOwed0).to.eq(0);
+    chai.expect(tokensOwed1).to.eq(0);
+  });
+
+  it("should unstake the LP NFT and receive tokens", async function () {
+    this.timeout(60 * 1000);
+
+    const {
+      assetTokenContract,
+      ausdcTokenProxyContract,
+      baseTokenContract,
+      curveAavePoolerContract,
+      curveAaveStakerContract,
+      lpSftContract,
+      uniswapV3NftManagerContract,
+      uniswapV3PoolContract,
+      uniswapV3StakerContract,
+      uniV3PoolerContract,
+      uniV3StakerContract,
+      uniV3SwapperContract,
+      usdcTokenContract,
+    } = contracts;
+
+    // Unstake the NFT and receive tokens
+    const tx: Promise<ethers.ContractTransaction> =
+      uniV3StakerContract.unstakeNFT(
+        nftTokenId, // tokenId
+        1, // USDC
+        beneficiaryAddress // recipient
+      );
+
+    // Get reward amount
+    const receipt: ethers.ContractReceipt = await (await tx).wait();
+    const iface: ethers.utils.Interface = new ethers.utils.Interface(
+      uniV3StakerAbi
+    );
+    const log = receipt.logs.find((log) => {
+      try {
+        return iface.parseLog(log).name === "NFTUnstaked";
+      } catch (e) {
+        return false;
+      }
+    });
+    const logDescription: ethers.utils.LogDescription = iface.parseLog(log);
+    const rewardClaimed: ethers.BigNumber = logDescription.args[4];
+    console.log(
+      "    Token rewards:",
+      rewardClaimed.div(ethers.BigNumber.from(10).pow(18)).toNumber(),
+      "tokens in",
+      REWARD_DELAY_HOURS,
+      "hours"
+    );
+
+    //
+    // Check routing events
+    //
+
+    await chai.expect(tx).to.emit(uniV3StakerContract, "NFTUnstaked").withArgs(
+      beneficiaryAddress, // sender
+      beneficiaryAddress, // recipient
+      uniswapV3NftManagerContract.address, // nftAddress
+      nftTokenId, // nftTokenId
+      rewardClaimed, // rewardClaimed
+      1, // stableIndex
+      USDC_RETURNED // stablesReturned
+    );
+    await chai.expect(tx).to.emit(uniV3PoolerContract, "NFTCollected").withArgs(
+      uniV3StakerContract.address, // sender
+      uniV3StakerContract.address, // recipient
+      uniswapV3NftManagerContract.address, // nftAddress
+      nftTokenId, // nftTokenId
+      UNISWAP_LP_AMOUNT, // liquidityAmount
+      BASE_TOKENS_COLLECTED, // baseTokensCollected
+      ASSET_TOKENS_COLLECTED, // assetTokensCollected
+      1, // stableIndex (USDC)
+      USDC_RETURNED // stablesReturned
+    );
+    await chai
+      .expect(tx)
+      .to.emit(uniV3SwapperContract, "TokensSoldForAsset")
+      .withArgs(
+        uniV3PoolerContract.address, // sender
+        uniV3PoolerContract.address, // recipient
+        BASE_TOKENS_COLLECTED, // baseTokenSpent
+        ASSET_TOKENS_RECEIVED // assetTokensReturned
+      );
+    await chai
+      .expect(tx)
+      .to.emit(curveAaveStakerContract, "GaugeUnstakedOneStable")
+      .withArgs(
+        uniV3PoolerContract.address, // sender
+        uniV3PoolerContract.address, // recipient
+        CURVE_AAVE_GAUGE_SHARES_UNSTAKED, // gaugeShares
+        1, // stableIndex (USDC)
+        USDC_RETURNED // stablesReturned
+      );
+    await chai
+      .expect(tx)
+      .to.emit(curveAavePoolerContract, "LiquidityRemovedOneStable")
+      .withArgs(
+        curveAaveStakerContract.address, // sender
+        curveAaveStakerContract.address, // recipient
+        CURVE_AAVE_LP_REMOVED, // lpTokenAmount
+        1, // stableIndex (USDC)
+        USDC_RETURNED // stablesReturned
+      );
+
+    //
+    // Check Uniswap V3 staker events
+    //
+
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3StakerContract, "TokenUnstaked")
+      .withArgs(
+        nftTokenId, // tokenId
+        incentiveId // incentiveId
+      );
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3StakerContract, "DepositTransferred")
+      .withArgs(
+        nftTokenId, // tokenId
+        uniV3StakerContract.address, // oldOwner
+        ethers.constants.AddressZero // newOwner
+      );
+
+    //
+    // Check Uniswap V3 NFT manager events
+    //
+
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3NftManagerContract, "DecreaseLiquidity")
+      .withArgs(
+        nftTokenId, // tokenId
+        UNISWAP_LP_AMOUNT, // liquidity
+        baseIsToken0 ? BASE_TOKENS_UNPOOLED : ASSET_TOKENS_UNPOOLED, // amount0
+        baseIsToken0 ? ASSET_TOKENS_UNPOOLED : BASE_TOKENS_UNPOOLED // amount1
+      );
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3NftManagerContract, "Collect")
+      .withArgs(
+        nftTokenId, // tokenId
+        uniV3PoolerContract.address, // recipient
+        baseIsToken0 ? BASE_TOKENS_COLLECTED : ASSET_TOKENS_COLLECTED, // amount0
+        baseIsToken0 ? ASSET_TOKENS_COLLECTED : BASE_TOKENS_COLLECTED // amount1
+      );
+
+    //
+    // Check Uniswap V3 pool events
+    //
+
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3PoolContract, "Burn")
+      .withArgs(
+        uniswapV3NftManagerContract.address, // owner
+        getMinTick(TICK_SPACINGS[FEE_AMOUNT.HIGH]), // tickLower
+        getMaxTick(TICK_SPACINGS[FEE_AMOUNT.HIGH]), // tickUpper
+        UNISWAP_LP_AMOUNT, // amount
+        baseIsToken0 ? BASE_TOKENS_UNPOOLED : ASSET_TOKENS_UNPOOLED, // amount0
+        baseIsToken0 ? ASSET_TOKENS_UNPOOLED : BASE_TOKENS_UNPOOLED // amount1
+      );
+
+    //
+    // Check LP SFT path
+    //
+
+    await chai.expect(tx).to.emit(lpSftContract, "TransferSingle").withArgs(
+      uniV3StakerContract.address, // operator
+      beneficiaryAddress, // from
+      ethers.constants.AddressZero, // to
+      nftTokenId, // tokenId
+      1 // value
+    );
+
+    //
+    // Check LP NFT path
+    //
+
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3NftManagerContract, "Transfer")
+      .withArgs(
+        uniswapV3StakerContract.address, // from
+        uniV3PoolerContract.address, // to
+        nftTokenId // tokenId
+      );
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3NftManagerContract, "Transfer")
+      .withArgs(
+        uniV3PoolerContract.address, // from
+        uniV3StakerContract.address, // to
+        nftTokenId // tokenId
+      );
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3NftManagerContract, "Transfer")
+      .withArgs(
+        uniV3StakerContract.address, // from
+        beneficiaryAddress, // to
+        nftTokenId // tokenId
+      );
+
+    //
+    // Check base token path
+    //
+
+    /*
+    await chai.expect(tx).to.emit(baseTokenContract, "Transfer").withArgs(
+      uniswapV3StakerContract.address, // from
+      uniV3StakerContract.address, // to
+      rewardClaimed // value
+    );
+    await chai.expect(tx).to.emit(baseTokenContract, "Transfer").withArgs(
+      uniswapV3PoolContract.address, // from
+      uniV3PoolerContract.address, // to
+      BASE_TOKENS_RETURNED // value
+    );
+    await chai.expect(tx).to.emit(baseTokenContract, "Transfer").withArgs(
+      uniV3PoolerContract.address, // from
+      uniV3StakerContract.address, // to
+      BASE_TOKENS_RETURNED // value
+    );
+    await chai.expect(tx).to.emit(baseTokenContract, "Transfer").withArgs(
+      uniV3StakerContract.address, // from
+      beneficiaryAddress, // to
+      BASE_TOKENS_RETURNED.add(rewardClaimed) // value
+    );
+
+    //
+    // Check asset token path
+    //
+
+    await chai.expect(tx).to.emit(assetTokenContract, "Transfer").withArgs(
+      uniswapV3PoolContract.address, // from
+      uniV3PoolerContract.address, // to
+      ASSET_TOKENS_RETURNED // value
+    );
+    await chai.expect(tx).to.emit(assetTokenContract, "Transfer").withArgs(
+      uniV3PoolerContract.address, // from
+      ethers.constants.AddressZero, // to
+      ASSET_TOKENS_RETURNED // value
+    );
+    */
+
+    //
+    // Check USDC path
+    //
+
+    await chai.expect(tx).to.emit(usdcTokenContract, "Transfer").withArgs(
+      ausdcTokenProxyContract.address, // from
+      curveAavePoolerContract.address, // to
+      USDC_RETURNED // value
+    );
+    await chai.expect(tx).to.emit(usdcTokenContract, "Transfer").withArgs(
+      curveAavePoolerContract.address, // from
+      curveAaveStakerContract.address, // to
+      USDC_RETURNED // value
+    );
+    await chai.expect(tx).to.emit(usdcTokenContract, "Transfer").withArgs(
+      curveAaveStakerContract.address, // from
+      uniV3PoolerContract.address, // to
+      USDC_RETURNED // value
+    );
+    await chai.expect(tx).to.emit(usdcTokenContract, "Transfer").withArgs(
+      uniV3PoolerContract.address, // from
+      uniV3StakerContract.address, // to
+      USDC_RETURNED // value
+    );
+    await chai.expect(tx).to.emit(usdcTokenContract, "Transfer").withArgs(
+      uniV3StakerContract.address, // from
+      beneficiaryAddress, // to
+      USDC_RETURNED // value
+    );
+  });
+
+  it("should check NFT position after collecting tokens", async function () {
+    this.timeout(60 * 1000);
+
+    const {
+      assetTokenContract,
+      baseTokenContract,
+      uniswapV3NftManagerContract,
+    } = contracts;
+
+    const position = await uniswapV3NftManagerContract.positions(nftTokenId);
+    const [
+      nonce,
+      operator,
+      token0,
+      token1,
+      fee,
+      tickLower,
+      tickUpper,
+      liquidity,
+      feeGrowthInside0LastX128,
+      feeGrowthInside1LastX128,
+      tokensOwed0,
+      tokensOwed1,
+    ] = position;
+
+    chai.expect(nonce).to.eq(0);
+    chai.expect(operator).to.eq(ethers.constants.AddressZero); // TODO: Why is this address(0)?
+    if (baseIsToken0) {
+      chai.expect(token0).to.eq(baseTokenContract.address);
+      chai.expect(token1).to.eq(assetTokenContract.address);
+    } else {
+      chai.expect(token0).to.eq(assetTokenContract.address);
+      chai.expect(token1).to.eq(baseTokenContract.address);
+    }
+    chai.expect(fee).to.eq(FEE_AMOUNT.HIGH);
+    chai.expect(tickLower).to.eq(getMinTick(TICK_SPACINGS[FEE_AMOUNT.HIGH]));
+    chai.expect(tickUpper).to.eq(getMaxTick(TICK_SPACINGS[FEE_AMOUNT.HIGH]));
+    chai.expect(liquidity).to.eq(0);
+    chai
+      .expect(decodeX128Int(feeGrowthInside0LastX128.mul(1_000_000)))
+      .to.eq(baseIsToken0 ? BASE_TOKEN_FEES : ASSET_TOKEN_FEES);
+    chai
+      .expect(decodeX128Int(feeGrowthInside1LastX128.mul(1_000_000)))
+      .to.eq(baseIsToken0 ? ASSET_TOKEN_FEES : BASE_TOKEN_FEES);
+    chai.expect(tokensOwed0).to.eq(0);
+    chai.expect(tokensOwed1).to.eq(0);
+  });
+
+  it("should burn the NFT", async function () {
+    this.timeout(60 * 1000);
+
+    const { uniswapV3NftManagerContract } = contracts;
+
+    const tx: Promise<ethers.ContractTransaction> =
+      uniswapV3NftManagerContract.burn(nftTokenId);
+    await chai
+      .expect(tx)
+      .to.emit(uniswapV3NftManagerContract, "Transfer")
+      .withArgs(beneficiaryAddress, ethers.constants.AddressZero, nftTokenId);
+  });
+});


### PR DESCRIPTION
## Description

This PR imports a complete example of how Tokenomics for Ultrachess could work on the Polygon network, backed by an extensive CI pipeline with a large test suite and static analysis for audit-grade security.

The basic model involves two tokens: A yield-bearing stable-based asset, and a yield-bearing LP-NFT-based asset. The idea is to enable non-zero-sum betting in two separate risk classes. Here's how they work:

### Yield-bearing stable asset (ultra3CRV)

All stablecoins in the system are deposited for ultra3CRV before portalling to L2. Starting by depositing any combination of 3 stables (USDC/DAI/USDT), the routing contract builds the following tower of yield:

* Stables are lent on Aave V2 (0.5-1.5% APY in interest)
* Aave tokens are pooled in the am3CRV Curve Aave pool (0.5% APY in MM fees)
* am3CRV is staked on Curve Gauge (0.2% APY in governance rewards)
* Staked am3CRV is deposited 1:1 for ultra3CRV

The result is ultra3CRV, which is stable in price and yields at a combined ~2.1% APY.

Users can bet any combination of the 3 underlying stables. They are deposited for ultra3CRV before portalling to L2, and liquidated back to the stablecoin of choice (plus accrued yield) when withdrawn.

#### Risk analysis

This allows for non-zero-sum betting of stablecoins with no market risk: Two players bet stable value, the winner is guaranteed the combined value plus the yield generated during the match.

#### Remaining work

* Add PoolTogether dependency for 9% APY on Optimism (ultraPTaOpt)

### Yield-bearing LP SFTs (staked CHESS/ultra3CRV)

The second type of non-zero-sum betting is based on Uniswap V3 LP NFTs staked in an SFT contract. The [ERC-1155](https://github.com/cartesi/rollups/pull/2) standard is used for staking to allow for batch transfers of chess pieces, chess boards and chess play, so the top level of the tower is a yield-bearing LP SFT.

![CHESS-ultra3CRV LP SFT](https://user-images.githubusercontent.com/15795328/217420293-bfca5517-c7bd-42bc-aa60-04ccb0bad0d8.png)

A base ERC-20 token is introduced, which for now has the symbol CHESS. However, it's not interacted with directly. Everything is stables-in, stables-out in a single smart contract call.

The routing contract performs the following tasks:

* Stables are deposited into ultra3CRV, as described above
* [About half](https://github.com/Ultrachess/contracts/blob/main/contracts/src/utils/math/LiquidityMath.sol) of the utlra3CRV is swapped for CHESS on Uniswap V3 
* CHESS and ultra3CRV are pooled on Uniswap V3 for an LP NFT
* The LP NFT is staked in exchange for an LP SFT
* The LP SFTs are batch-portalled to L2

Liquidation happens in reverse; the LP SFT is withdrawn, swapped for the underlying LP NFT and accrued MM fees and liquidity rewards, and everything is liquidated back to stablecoins, all in a single contract call. Instead of burning the empty Uniswap V3 LP NFT, it's returned to the user as a keepsake.

#### LP NFTs

NFTs are desirable tokens for an in-game asset, because they can represent chess pieces, chess boards, and chess plays. However, NFTs don't allow betting, because the intrinsic value is nonfungible and can't be compared, so each player needs to get their individual NFT back.

LP NFTs, on the other hand, have a dimension of fungibility against each other: their accrued market yield. Players can bet LP NFTs, then after the match, the players get back their LP NFT, and the winner gets the yield: "Bet liquidity, win the yield".

#### Risk analysis

This form of non-zero-sum betting is more difficult to analyze for risk, because it involves market components.

When you liquidate ultra3CRV, you're guaranteed to get back more than you deposit. However, when you liquidate the LP SFT, the value might have gone up or down due slightly to the risk of Impermanent Loss. To account for this, the risk of IL is offset in several ways:

* 1% of match bets is taken by the protocol and used to burn CHESS at market price, pushing the price of the liquidity up with the square root of the price of CHESS
* A VR-GDA (variable rate gradual dutch auction) for LP NFT chess assets grows the liquidity pool, pushing the price of CHESS up
* CHESS is liquid against a yield-bearing asset, pushing the price up with the square root of the accrued stable yield
* LP NFTs make 1% in fees on every swap, pushing the price of the liquidity up linear to the trade volume
* Depositing stables into the liquidity pool requires swapping half of the ultra3CRV for CHESS, increasing trade volume and thus MM fees

Against these forcing functions pushing the price up, there's also forces pushing the price down:

* Because depositing stables requires swapping half to CHESS, there's a 0.5% fee to deposit and a 0.5% fee to liquidate, pushing the price of the liquidity down
* Because profits are taken in stables, the value of CHESS can fall, pushing the price of liquidity down with the square root of the fall in value of CHESS

The non-zero-sum reward is analyzed with the expectation that the net result is a drop in price of the LP SFT's liquidity.

However, pairing with a stable asset is key, because the expected loss only scales with the square root of the drop in price of CHESS. As a result, the _large_ accrued total yield outweighs the _small_ two drops in value, so the system becomes a positive-sum betting game. One player experiences a small loss, the other player experiences a large gain. On average, two equally-matched players win small every game.

In other words: "Bet liquidity, win the yield." 

It's worth mentioning that in the early adoption phase, as liquidity flows into the system, the losing LP SFT holder wins big, and the winning LP SFT holder wins bigger, hypercharging growth.

#### Remaining work

* Reward distribution at the top-most LP SFT staking layer
* Update one-sided LP supply calculation using Tick Math for concentrated liquidity chess sets (kings are high-yield, high-concentration, pawns are low-yield, low concentation)

## Related PRs

* Depends on https://github.com/cartesi/rollups/pull/2

## How has this been tested?

The following checks are run on GitHub Actions CI:

* Yarn dependency audit
* Prettier format check
* ESLint linting for Typescript code
* Solhint linting for smart contracts
* Slither static analysis for smart contracts

See CI results for current test passing status.